### PR TITLE
FIX: crash AmqpException thrown w/no method/class

### DIFF
--- a/src/AmqpException.cpp
+++ b/src/AmqpException.cpp
@@ -76,22 +76,40 @@ void AmqpException::Throw(const amqp_rpc_reply_t& reply)
 
 void AmqpException::Throw(const amqp_channel_close_t& reply)
 {
+  std::ostringstream what;
+
+  std::string reply_text;
+  if (reply.reply_text.bytes != NULL)
+  {
+    reply_text = std::string((char*)reply.reply_text.bytes, reply.reply_text.len);
+  }
+
+  const char* method_name = amqp_method_name(((reply.class_id << 16) | reply.method_id));
+  if (method_name != NULL)
+  {
+    what << "channel error: " << reply.reply_code << ": " << method_name << " caused: " << reply_text;
+  }
+  else
+  {
+    what << "channel error: " << reply.reply_code << ": " << reply_text;
+  }
+
   switch (reply.reply_code)
   {
   case ContentTooLargeException::REPLY_CODE:
-    throw ContentTooLargeException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw ContentTooLargeException(what.str(), reply_text, reply.class_id, reply.method_id);
   case NoRouteException::REPLY_CODE:
-    throw NoRouteException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw NoRouteException(what.str(), reply_text, reply.class_id, reply.method_id);
   case NoConsumersException::REPLY_CODE:
-    throw NoConsumersException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw NoConsumersException(what.str(), reply_text, reply.class_id, reply.method_id);
   case AccessRefusedException::REPLY_CODE:
-    throw AccessRefusedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw AccessRefusedException(what.str(), reply_text, reply.class_id, reply.method_id);
   case NotFoundException::REPLY_CODE:
-    throw NotFoundException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw NotFoundException(what.str(), reply_text, reply.class_id, reply.method_id);
   case ResourceLockedException::REPLY_CODE:
-    throw ResourceLockedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw ResourceLockedException(what.str(), reply_text, reply.class_id, reply.method_id);
   case PreconditionFailedException::REPLY_CODE:
-    throw PreconditionFailedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw PreconditionFailedException(what.str(), reply_text, reply.class_id, reply.method_id);
   default:
     throw std::logic_error(std::string("Programming error: unknown channel reply code: ").append(boost::lexical_cast<std::string>(reply.reply_code)));
   }
@@ -99,37 +117,55 @@ void AmqpException::Throw(const amqp_channel_close_t& reply)
 
 void AmqpException::Throw(const amqp_connection_close_t& reply)
 {
+  std::ostringstream what;
+  const char* method_name = amqp_method_name(((reply.class_id << 16) | reply.method_id));
+
+  std::string reply_text;
+  if (reply.reply_text.bytes != NULL)
+  {
+    reply_text = std::string((char*)reply.reply_text.bytes, reply.reply_text.len);
+  }
+
+  if (method_name != NULL)
+  {
+    what << "connection error: " << reply.reply_code << ": " << method_name << " caused: " << reply_text;
+  }
+  else
+  {
+    what << "connection error: " << reply.reply_code << ": " << reply_text;
+  }
+
   switch (reply.reply_code)
   {
   case ConnectionForcedException::REPLY_CODE:
-    throw ConnectionForcedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw ConnectionForcedException(what.str(), reply_text, reply.class_id, reply.method_id);
   case InvalidPathException::REPLY_CODE:
-    throw InvalidPathException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw InvalidPathException(what.str(), reply_text, reply.class_id, reply.method_id);
   case FrameErrorException::REPLY_CODE:
-    throw FrameErrorException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw FrameErrorException(what.str(), reply_text, reply.class_id, reply.method_id);
   case SyntaxErrorException::REPLY_CODE:
-    throw SyntaxErrorException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw SyntaxErrorException(what.str(), reply_text, reply.class_id, reply.method_id);
   case CommandInvalidException::REPLY_CODE:
-    throw CommandInvalidException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw CommandInvalidException(what.str(), reply_text, reply.class_id, reply.method_id);
   case ChannelErrorException::REPLY_CODE:
-    throw ChannelErrorException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw ChannelErrorException(what.str(), reply_text, reply.class_id, reply.method_id);
   case UnexpectedFrameException::REPLY_CODE:
-    throw UnexpectedFrameException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw UnexpectedFrameException(what.str(), reply_text, reply.class_id, reply.method_id);
   case ResourceErrorException::REPLY_CODE:
-    throw ResourceErrorException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw ResourceErrorException(what.str(), reply_text, reply.class_id, reply.method_id);
   case NotAllowedException::REPLY_CODE:
-    throw NotAllowedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw NotAllowedException(what.str(), reply_text, reply.class_id, reply.method_id);
   case NotImplementedException::REPLY_CODE:
-    throw NotImplementedException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw NotImplementedException(what.str(), reply_text, reply.class_id, reply.method_id);
   case InternalErrorException::REPLY_CODE:
-    throw InternalErrorException(std::string((char*)reply.reply_text.bytes, reply.reply_text.len), reply.class_id, reply.method_id);
+    throw InternalErrorException(what.str(), reply_text, reply.class_id, reply.method_id);
   default:
     throw std::logic_error(std::string("Programming error: unknown connection reply code: ").append(boost::lexical_cast<std::string>(reply.reply_code)));
   }
 }
 
-AmqpException::AmqpException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-      std::runtime_error(std::string(amqp_method_name((class_id << 16) | method_id)).append(" caused: ").append(reply_text)),
+AmqpException::AmqpException(const std::string& what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+      std::runtime_error(what),
       m_reply_text(reply_text),
       m_class_id(class_id),
       m_method_id(method_id)

--- a/src/SimpleAmqpClient/AmqpException.h
+++ b/src/SimpleAmqpClient/AmqpException.h
@@ -53,7 +53,7 @@ public:
   static void Throw(const amqp_channel_close_t_& reply);
   static void Throw(const amqp_connection_close_t_& reply);
 
-  explicit AmqpException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw();
+  explicit AmqpException(const std::string& what, const std::string &reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw();
   virtual ~AmqpException() throw() {}
   
   virtual bool is_soft_error() const throw() = 0;
@@ -71,8 +71,8 @@ protected:
 class SIMPLEAMQPCLIENT_EXPORT ConnectionException : public AmqpException
 {
 public:
-  explicit ConnectionException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    AmqpException(std::string("connection exception: ").append(reply_text), class_id, method_id) {}
+  explicit ConnectionException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    AmqpException(what, reply_text, class_id, method_id) {}
 
   virtual bool is_soft_error() const throw() { return false; }
 };
@@ -80,8 +80,8 @@ public:
 class SIMPLEAMQPCLIENT_EXPORT ChannelException : public AmqpException
 {
 public:
-  explicit ChannelException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    AmqpException(std::string("channel exception: ").append(reply_text), class_id, method_id) {}
+  explicit ChannelException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    AmqpException(what, reply_text, class_id, method_id) {}
 
   virtual bool is_soft_error() const throw() { return true; }
 };
@@ -90,8 +90,8 @@ class SIMPLEAMQPCLIENT_EXPORT ConnectionForcedException : public ConnectionExcep
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit ConnectionForcedException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit ConnectionForcedException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -100,8 +100,8 @@ class SIMPLEAMQPCLIENT_EXPORT InvalidPathException : public ConnectionException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit InvalidPathException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit InvalidPathException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -110,8 +110,8 @@ class SIMPLEAMQPCLIENT_EXPORT FrameErrorException : public ConnectionException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit FrameErrorException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit FrameErrorException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -120,8 +120,8 @@ class SIMPLEAMQPCLIENT_EXPORT SyntaxErrorException : public ConnectionException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit SyntaxErrorException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit SyntaxErrorException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -130,8 +130,8 @@ class SIMPLEAMQPCLIENT_EXPORT CommandInvalidException : public ConnectionExcepti
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit CommandInvalidException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit CommandInvalidException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -140,8 +140,8 @@ class SIMPLEAMQPCLIENT_EXPORT ChannelErrorException : public ConnectionException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit ChannelErrorException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit ChannelErrorException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -150,8 +150,8 @@ class SIMPLEAMQPCLIENT_EXPORT UnexpectedFrameException : public ConnectionExcept
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit UnexpectedFrameException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit UnexpectedFrameException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -160,8 +160,8 @@ class SIMPLEAMQPCLIENT_EXPORT ResourceErrorException : public ConnectionExceptio
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit ResourceErrorException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit ResourceErrorException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -170,8 +170,8 @@ class SIMPLEAMQPCLIENT_EXPORT NotAllowedException : public ConnectionException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit NotAllowedException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit NotAllowedException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -180,8 +180,8 @@ class SIMPLEAMQPCLIENT_EXPORT NotImplementedException : public ConnectionExcepti
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit NotImplementedException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit NotImplementedException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -190,8 +190,8 @@ class SIMPLEAMQPCLIENT_EXPORT InternalErrorException : public ConnectionExceptio
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit InternalErrorException(const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ConnectionException(reply_text, class_id, method_id) {}
+  explicit InternalErrorException(const std::string &what, const std::string& reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ConnectionException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -200,8 +200,8 @@ class SIMPLEAMQPCLIENT_EXPORT ContentTooLargeException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit ContentTooLargeException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit ContentTooLargeException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -210,8 +210,8 @@ class SIMPLEAMQPCLIENT_EXPORT NoRouteException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit NoRouteException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit NoRouteException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -219,8 +219,8 @@ class SIMPLEAMQPCLIENT_EXPORT NoConsumersException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit NoConsumersException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit NoConsumersException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -229,8 +229,8 @@ class SIMPLEAMQPCLIENT_EXPORT AccessRefusedException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit AccessRefusedException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit AccessRefusedException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -239,8 +239,8 @@ class SIMPLEAMQPCLIENT_EXPORT NotFoundException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit NotFoundException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit NotFoundException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -249,8 +249,8 @@ class SIMPLEAMQPCLIENT_EXPORT ResourceLockedException : public ChannelException
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit ResourceLockedException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit ResourceLockedException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };
@@ -259,8 +259,8 @@ class SIMPLEAMQPCLIENT_EXPORT PreconditionFailedException : public ChannelExcept
 {
 public:
   static const boost::uint16_t REPLY_CODE;
-  explicit PreconditionFailedException(const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
-    ChannelException(reply_text, class_id, method_id) {}
+  explicit PreconditionFailedException(const std::string &what, const std::string reply_text, boost::uint16_t class_id, boost::uint16_t method_id) throw() :
+    ChannelException(what, reply_text, class_id, method_id) {}
 
   virtual boost::uint16_t reply_code() const throw() { return REPLY_CODE; }
 };


### PR DESCRIPTION
This is a fix for Issue #12

Reworked the constructors and static Throw() method
to check the results of amqp_method_name before
trying to use it (returns NULL on error)
