### PR TITLE
Fix for issue #22: #include <string> in AmqpException.h

### DIFF
--- a/src/SimpleAmqpClient/AmqpException.h
+++ b/src/SimpleAmqpClient/AmqpException.h
@@ -33,6 +33,7 @@
 #include <boost/cstdint.hpp>
 
 #include <stdexcept>
+#include <string>
 
 #ifdef _MSC_VER
 # pragma warning ( push )


### PR DESCRIPTION
AmqpException.h should #include <string>.

CC: issue #22
