### PR TITLE
Call MaybeReleaseBuffers when AmqpException is thrown

### DIFF
--- a/src/SimpleAmqpClient/ChannelImpl.h
+++ b/src/SimpleAmqpClient/ChannelImpl.h
@@ -114,7 +114,15 @@ public:
         AMQP_CHANNEL_CLOSE_METHOD == incoming_frame.payload.method.id)
       {
         FinishCloseChannel(channel);
-        AmqpException::Throw(*reinterpret_cast<amqp_channel_close_t*>(incoming_frame.payload.method.decoded));
+        try
+        {
+          AmqpException::Throw(*reinterpret_cast<amqp_channel_close_t*>(incoming_frame.payload.method.decoded));
+        }
+        catch (AmqpException&)
+        {
+          MaybeReleaseBuffers();
+          throw;
+        }
       }
       GetChannelQueueOrThrow(channel)->second.push_back(incoming_frame);
 


### PR DESCRIPTION
SimpleAmqpClient doesn't call MaybeReleaseBuffers when it throws
an AmqpException, which is ok if it happens infrequently as
the memory will get released the next successful API calls
MaybeReleaseBuffers.  However, in the case where the API is
continually called in a way that causes channel.close methods to be
returned (e.g., exchange gets destroyed and the client continues
to publish to the exchange that doens't exist), the memory
used by each return method frame is never released.

This fixes that.

This is a fix for Issue #28
