### PR TITLE
FIX: missing declaration of free() in AmqpResponseLibraryException.cpp

### DIFF
--- a/src/AmqpResponseLibraryException.cpp
+++ b/src/AmqpResponseLibraryException.cpp
@@ -31,6 +31,7 @@
 
 #include "SimpleAmqpClient/AmqpResponseLibraryException.h"
 
+#include <stdlib.h>
 
 namespace AmqpClient {
 


### PR DESCRIPTION
Need to add #include <stdlib.h> in AmqpResponseLibraryException.cpp
as it fails to compile under MinGW/Cygwin with undefined errors.
