### PR TITLE
Add Channel::CancelConsume() to cancel BasicConsumeMessage

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -668,4 +668,14 @@ bool Channel::BasicConsumeMessage(const std::string& consumer_tag, Envelope::ptr
   return true;
 }
 
+void Channel::CancelConsume()
+{
+  // a single byte to send over pipe
+  char buf[1];
+  buf[0]=0;
+ 
+  // write to pipe to cancel basic message consume call
+  write(m_impl->m_pipe[1], buf, 1);
+}
+   
 } // namespace AmqpClient

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -529,6 +529,13 @@ public:
 	  */
 	bool BasicConsumeMessage(const std::string& consumer_tag, Envelope::ptr_t& envelope, int timeout = -1);
 
+    /**
+      *  Cancel a running consume call
+      *  If you've called BasicConsumeMessage that is now blocking, this method
+      *  can be called from a different thread to wakeup the consume call.
+      */
+    void CancelConsume();
+
 protected:
     boost::scoped_ptr<Detail::ChannelImpl> m_impl;
 };

--- a/src/SimpleAmqpClient/ChannelImpl.h
+++ b/src/SimpleAmqpClient/ChannelImpl.h
@@ -180,7 +180,8 @@ public:
   void SetIsConnected(bool state) { m_is_connected = state; }
 
   amqp_connection_state_t m_connection;
-
+  int m_pipe[2];
+  
 private:
   std::map<std::string, amqp_channel_t> m_consumer_channel_map;
   channel_map_t m_open_channels;


### PR DESCRIPTION
This method cancels BasicConsumeMessage as if it timed out immediately.
Internaly it uses pipe() to listen to in select() call in
GetNextFrameFromBroker(). This way different thread can write a byte
to the pipe, causing BasicConsumeMessage to timeout immetiately.