### PR TITLE
Added a DeclareQueueWithCounts() function

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -310,56 +310,56 @@ std::string Channel::DeclareQueue(const std::string &queue_name,
                                   bool auto_delete,
                                   const Table &arguments)
 {
-	boost::uint32_t message_count;
-	boost::uint32_t consumer_count;
-	return DeclareQueueWithCounts(queue_name, message_count, consumer_count, passive, durable, exclusive, auto_delete, arguments);
+    boost::uint32_t message_count;
+    boost::uint32_t consumer_count;
+    return DeclareQueueWithCounts(queue_name, message_count, consumer_count, passive, durable, exclusive, auto_delete, arguments);
 }
 
 std::string Channel::DeclareQueueWithCounts(const std::string &queue_name,
-	boost::uint32_t &message_count,
-	boost::uint32_t &consumer_count,
-	bool passive,
-	bool durable,
-	bool exclusive,
-	bool auto_delete)
+                                            boost::uint32_t &message_count,
+                                            boost::uint32_t &consumer_count,
+                                            bool passive,
+                                            bool durable,
+                                            bool exclusive,
+                                            bool auto_delete)
 {
-	return DeclareQueueWithCounts(queue_name, message_count, consumer_count, passive, durable, exclusive, auto_delete, Table());
+    return DeclareQueueWithCounts(queue_name, message_count, consumer_count, passive, durable, exclusive, auto_delete, Table());
 }
 
 std::string Channel::DeclareQueueWithCounts(const std::string &queue_name,
-	boost::uint32_t &message_count,
-	boost::uint32_t &consumer_count,
-	bool passive,
-	bool durable,
-	bool exclusive,
-	bool auto_delete,
-	const Table &arguments)
+                                            boost::uint32_t &message_count,
+                                            boost::uint32_t &consumer_count,
+                                            bool passive,
+                                            bool durable,
+                                            bool exclusive,
+                                            bool auto_delete,
+                                            const Table &arguments)
 {
-	const boost::array<boost::uint32_t, 1> DECLARE_OK = { { AMQP_QUEUE_DECLARE_OK_METHOD } };
-	m_impl->CheckIsConnected();
-
-	amqp_queue_declare_t declare = {};
-	declare.queue = amqp_cstring_bytes(queue_name.c_str());
-	declare.passive = passive;
-	declare.durable = durable;
-	declare.exclusive = exclusive;
-	declare.auto_delete = auto_delete;
-	declare.nowait = false;
-
-	Detail::amqp_pool_ptr_t table_pool;
-	declare.arguments = Detail::TableValueImpl::CreateAmqpTable(arguments, table_pool);
-
-	amqp_frame_t response = m_impl->DoRpc(AMQP_QUEUE_DECLARE_METHOD, &declare, DECLARE_OK);
-
-	amqp_queue_declare_ok_t *declare_ok = (amqp_queue_declare_ok_t *)response.payload.method.decoded;
-
-	std::string ret((char *)declare_ok->queue.bytes, declare_ok->queue.len);
-
-	message_count = declare_ok->message_count;
-	consumer_count = declare_ok->consumer_count;
-
-	m_impl->MaybeReleaseBuffersOnChannel(response.channel);
-	return ret;
+    const boost::array<boost::uint32_t, 1> DECLARE_OK = { { AMQP_QUEUE_DECLARE_OK_METHOD } };
+    m_impl->CheckIsConnected();
+    
+    amqp_queue_declare_t declare = {};
+    declare.queue = amqp_cstring_bytes(queue_name.c_str());
+    declare.passive = passive;
+    declare.durable = durable;
+    declare.exclusive = exclusive;
+    declare.auto_delete = auto_delete;
+    declare.nowait = false;
+    
+    Detail::amqp_pool_ptr_t table_pool;
+    declare.arguments = Detail::TableValueImpl::CreateAmqpTable(arguments, table_pool);
+    
+    amqp_frame_t response = m_impl->DoRpc(AMQP_QUEUE_DECLARE_METHOD, &declare, DECLARE_OK);
+    
+    amqp_queue_declare_ok_t *declare_ok = (amqp_queue_declare_ok_t *)response.payload.method.decoded;
+    
+    std::string ret((char *)declare_ok->queue.bytes, declare_ok->queue.len);
+    
+    message_count = declare_ok->message_count;
+    consumer_count = declare_ok->consumer_count;
+    
+    m_impl->MaybeReleaseBuffersOnChannel(response.channel);
+    return ret;
 }
 
 

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -316,7 +316,7 @@ public:
                              bool auto_delete,
                              const Table &arguments);
 
-	    /**
+    /**
       * Declares a queue and returns current message- and consumer counts
       * Creates a queue on the AMQP broker if it does not already exist
       * @param queue_name the desired name of the queue. If this is a zero-length string the broker
@@ -332,19 +332,19 @@ public:
       * @param durable Indicates whether the exchange is durable - e.g., will it survive a broker restart
       *  Defaults to false
       * @param exclusive Indicates that only client can use the queue. Defaults to true. An
-    *  exclusive queue is deleted when the connection is closed
+      *  exclusive queue is deleted when the connection is closed
       * @param auto_delete the queue will be deleted after at least one exchange has been bound to it,
-    *  then has been unbound
+      *  then has been unbound
       * @returns the name of the queue created on the broker. Used mostly when the broker is asked to
       *  create a unique queue by not providing a queue name
       */
-	std::string DeclareQueueWithCounts(const std::string &queue_name,
-                             boost::uint32_t &message_count,
-                             boost::uint32_t &consumer_count,
-                             bool passive = false,
-                             bool durable = false,
-                             bool exclusive = true,
-                             bool auto_delete = true);
+    std::string DeclareQueueWithCounts(const std::string &queue_name,
+                                       boost::uint32_t &message_count,
+                                       boost::uint32_t &consumer_count,
+                                       bool passive = false,
+                                       bool durable = false,
+                                       bool exclusive = true,
+                                       bool auto_delete = true);
 
     /**
       * Declares a queue and returns current message- and consumer counts
@@ -362,21 +362,21 @@ public:
       * @param durable Indicates whether the exchange is durable - e.g., will it survive a broker restart
       *  Defaults to false
       * @param exclusive Indicates that only client can use the queue. Defaults to true. An
-    *  exclusive queue is deleted when the connection is closed
+      *  exclusive queue is deleted when the connection is closed
       * @param auto_delete the queue will be deleted after at least one exchange has been bound to it,
-    *  then has been unbound
-    * @param arguments A table of additional arguments used when declaring a queue
+      *  then has been unbound
+      * @param arguments A table of additional arguments used when declaring a queue
       * @returns the name of the queue created on the broker. Used mostly when the broker is asked to
       *  create a unique queue by not providing a queue name
       */
     std::string DeclareQueueWithCounts(const std::string &queue_name,
-                             boost::uint32_t &message_count,
-                             boost::uint32_t &consumer_count,
-                             bool passive,
-                             bool durable,
-                             bool exclusive,
-                             bool auto_delete,
-                             const Table &arguments);
+                                       boost::uint32_t &message_count,
+                                       boost::uint32_t &consumer_count,
+                                       bool passive,
+                                       bool durable,
+                                       bool exclusive,
+                                       bool auto_delete,
+                                       const Table &arguments);
 
     /**
       * Deletes a queue

--- a/testing/test_queue.cpp
+++ b/testing/test_queue.cpp
@@ -79,58 +79,58 @@ TEST_F(connected_test, queue_declare_notautodelete)
 
 TEST_F(connected_test, queue_declare_counts)
 {
-	boost::uint32_t message_count = 123;
-	boost::uint32_t consumer_count = 123;
-
-	std::string queue = channel->DeclareQueueWithCounts("queue_declare_counts", message_count, consumer_count);
-
-	EXPECT_NE("", queue);
-	EXPECT_EQ(0, message_count);
-	EXPECT_EQ(0, consumer_count);
-
-	const std::string body("Test Message");
-	BasicMessage::ptr_t out_message = BasicMessage::Create(body);
-	channel->BasicPublish("", queue, out_message);
-	channel->BasicPublish("", queue, out_message);
-	channel->BasicPublish("", queue, out_message);
-
-	std::string queue2 = channel->DeclareQueueWithCounts("queue_declare_counts", message_count, consumer_count);
-
-	EXPECT_NE("", queue2);
-	EXPECT_EQ(3, message_count);
-	EXPECT_EQ(0, consumer_count);
-
-	channel->DeleteQueue(queue);
+    boost::uint32_t message_count = 123;
+    boost::uint32_t consumer_count = 123;
+    
+    std::string queue = channel->DeclareQueueWithCounts("queue_declare_counts", message_count, consumer_count);
+    
+    EXPECT_NE("", queue);
+    EXPECT_EQ(0, message_count);
+    EXPECT_EQ(0, consumer_count);
+    
+    const std::string body("Test Message");
+    BasicMessage::ptr_t out_message = BasicMessage::Create(body);
+    channel->BasicPublish("", queue, out_message);
+    channel->BasicPublish("", queue, out_message);
+    channel->BasicPublish("", queue, out_message);
+    
+    std::string queue2 = channel->DeclareQueueWithCounts("queue_declare_counts", message_count, consumer_count);
+    
+    EXPECT_NE("", queue2);
+    EXPECT_EQ(3, message_count);
+    EXPECT_EQ(0, consumer_count);
+    
+    channel->DeleteQueue(queue);
 }
 
 TEST_F(connected_test, queue_declare_counts_table)
 {
-	boost::uint32_t message_count = 123;
-	boost::uint32_t consumer_count = 123;
-
-	Table qTable;
-
-	qTable.insert(TableEntry(TableKey("IsATest"), TableValue(true)));
-
-	std::string queue = channel->DeclareQueueWithCounts("queue_declare_counts_table", message_count, consumer_count, false, false, true, true, qTable);
-
-	EXPECT_NE("", queue);
-	EXPECT_EQ(0, message_count);
-	EXPECT_EQ(0, consumer_count);
-
-	const std::string body("Test Message");
-	BasicMessage::ptr_t out_message = BasicMessage::Create(body);
-	channel->BasicPublish("", queue, out_message);
-	channel->BasicPublish("", queue, out_message);
-	channel->BasicPublish("", queue, out_message);
-
-	std::string queue2 = channel->DeclareQueueWithCounts("queue_declare_counts_table", message_count, consumer_count, false, false, true, true, qTable);
-
-	EXPECT_NE("", queue2);
-	EXPECT_EQ(3, message_count);
-	EXPECT_EQ(0, consumer_count);
-
-	channel->DeleteQueue(queue);
+    boost::uint32_t message_count = 123;
+    boost::uint32_t consumer_count = 123;
+    
+    Table qTable;
+    
+    qTable.insert(TableEntry(TableKey("IsATest"), TableValue(true)));
+    
+    std::string queue = channel->DeclareQueueWithCounts("queue_declare_counts_table", message_count, consumer_count, false, false, true, true, qTable);
+    
+    EXPECT_NE("", queue);
+    EXPECT_EQ(0, message_count);
+    EXPECT_EQ(0, consumer_count);
+    
+    const std::string body("Test Message");
+    BasicMessage::ptr_t out_message = BasicMessage::Create(body);
+    channel->BasicPublish("", queue, out_message);
+    channel->BasicPublish("", queue, out_message);
+    channel->BasicPublish("", queue, out_message);
+    
+    std::string queue2 = channel->DeclareQueueWithCounts("queue_declare_counts_table", message_count, consumer_count, false, false, true, true, qTable);
+    
+    EXPECT_NE("", queue2);
+    EXPECT_EQ(3, message_count);
+    EXPECT_EQ(0, consumer_count);
+    
+    channel->DeleteQueue(queue);
 }
 
 TEST_F(connected_test, queue_delete)


### PR DESCRIPTION
Currently, SimpleAmqpClient has no means to check consumer and message counts in a declared queue, which is required in some cases (e.g. to display these values or prevent a queue to get too large). Added a new function which returns these figures, and changed the DeclareQueue() functions to call the new one so there is no duplicate code.
