### PR TITLE
Need to include Winsock2.h for struct timeval

### DIFF
--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -27,6 +27,17 @@
  * ***** END LICENSE BLOCK *****
  */
 
+#ifdef _WIN32
+# define NOMINMAX
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <Winsock2.h>
+#else
+# include <sys/types.h>
+# include <sys/time.h>
+#endif
+
 #include "SimpleAmqpClient/ChannelImpl.h"
 #include "SimpleAmqpClient/AmqpResponseLibraryException.h"
 #include "SimpleAmqpClient/AmqpException.h"


### PR DESCRIPTION
Need to include the Winsock2.h header on Win32 in order to get the struct
timeval definition in `ChannelImpl.cpp`

This is a fix for issue #68 
