### PR TITLE
C++ 11 support

### DIFF
--- a/src/SimpleAmqpClient/BasicMessage.h
+++ b/src/SimpleAmqpClient/BasicMessage.h
@@ -67,9 +67,6 @@ public:
         dm_persistent = 2
     };
 
-    friend ptr_t boost::make_shared<BasicMessage>();
-    friend ptr_t boost::make_shared<BasicMessage>(std::string const &a1);
-    friend ptr_t boost::make_shared<BasicMessage>(amqp_bytes_t_ const &a1, amqp_basic_properties_t_* const &a2);
 
     /**
       * Create a new empty BasicMessage object

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -65,9 +65,6 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable
 {
 public:
     typedef boost::shared_ptr<Channel> ptr_t;
-    friend ptr_t boost::make_shared<Channel>(std::string const &a1, int const &a2,
-            std::string const &a3, std::string const &a4,
-            std::string const &a5, int const &a6);
 
     static const std::string EXCHANGE_TYPE_DIRECT;
     static const std::string EXCHANGE_TYPE_FANOUT;

--- a/src/SimpleAmqpClient/Envelope.h
+++ b/src/SimpleAmqpClient/Envelope.h
@@ -52,8 +52,6 @@ class SIMPLEAMQPCLIENT_EXPORT Envelope : boost::noncopyable
 public:
     typedef boost::shared_ptr<Envelope> ptr_t;
 
-    friend ptr_t boost::make_shared<Envelope>(AmqpClient::BasicMessage::ptr_t const &a1, std::string const &a2, boost::uint64_t const &a3,
-            std::string const &a4, bool const &a5, std::string const &a6, boost::uint16_t const &a7);
 
     /**
       * Creates an new envelope object


### PR DESCRIPTION
deleted friend declaration to make_shared, they are not needed since
constructors are  public.

it's not great, but it's work, I only tested on GCC 4.6.3
