### PR TITLE
Add verify_hostname param to Channel::CreateSecure

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -129,9 +129,7 @@ Channel::Channel(const std::string &host,
                  const std::string &password,
                  const std::string &vhost,
                  int frame_max,
-                 const std::string &path_to_ca_cert,
-                 const std::string &path_to_client_key,
-                 const std::string &path_to_client_cert)
+                 const SSLConnectionParams &ssl_params)
     : m_impl(new Detail::ChannelImpl)
 {
     m_impl->m_connection = amqp_new_connection();
@@ -145,21 +143,22 @@ Channel::Channel(const std::string &host,
     {
         throw std::bad_alloc();
     }
+    amqp_ssl_socket_set_verify(socket, ssl_params.verify_hostname);
 
     try
     {
-        int status = amqp_ssl_socket_set_cacert(socket, path_to_ca_cert.c_str());
+        int status = amqp_ssl_socket_set_cacert(socket, ssl_params.path_to_ca_cert.c_str());
         if (status)
         {
             throw std::runtime_error("Error in setting CA certificate for socket");
         }
 
-        if (path_to_client_key != ""
-                && path_to_client_cert != "")
+        if (ssl_params.path_to_client_key != ""
+                && ssl_params.path_to_client_cert != "")
         {
             status = amqp_ssl_socket_set_key(socket,
-                                             path_to_client_cert.c_str(),
-                                             path_to_client_key.c_str());
+                                             ssl_params.path_to_client_cert.c_str(),
+                                             ssl_params.path_to_client_key.c_str());
             if (status)
             {
                 throw std::runtime_error("Error in setting client certificate for socket");

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -94,6 +94,15 @@ public:
         return boost::make_shared<Channel>(host, port, username, password, vhost, frame_max);
     }
 
+protected:
+    struct SSLConnectionParams {
+        std::string path_to_ca_cert;
+        std::string path_to_client_key;
+        std::string path_to_client_cert;
+        bool verify_hostname;
+    };
+
+public:
     /**
     * Creates a new channel object
     * Creates a new connection to an AMQP broker using the supplied parameters and opens
@@ -109,6 +118,8 @@ public:
     * @param channel_max Request that the server limit the number of channels for
     * this connection to the specified parameter, a value of zero will use the broker-supplied value
     * @param frame_max Request that the server limit the maximum size of any frame to this value
+    * @param verify_host Verify the hostname against the certificate when
+    * opening the SSL connection.
     *
     * @return a new Channel object pointer
     */
@@ -121,17 +132,22 @@ public:
                               const std::string &username = "guest",
                               const std::string &password = "guest",
                               const std::string &vhost = "/",
-                              int frame_max = 131072)
+                              int frame_max = 131072,
+                              bool verify_hostname = true)
     {
+        SSLConnectionParams ssl_params;
+        ssl_params.path_to_ca_cert = path_to_ca_cert;
+        ssl_params.path_to_client_key = path_to_client_key;
+        ssl_params.path_to_client_cert = path_to_client_cert;
+        ssl_params.verify_hostname = verify_hostname;
+
         return boost::make_shared<Channel>(host,
                                            port,
                                            username,
                                            password,
                                            vhost,
                                            frame_max,
-                                           path_to_ca_cert,
-                                           path_to_client_key,
-                                           path_to_client_cert);
+                                           ssl_params);
     }
 
 
@@ -157,9 +173,7 @@ public:
                      const std::string &password,
                      const std::string &vhost,
                      int frame_max,
-                     const std::string &path_to_ca_cert,
-                     const std::string &path_to_client_key,
-                     const std::string &path_to_client_cert);
+                     const SSLConnectionParams &ssl_params);
 
 
 public:


### PR DESCRIPTION
Add parameter to Channel::CreateSecure to control host verification when
establishing SSL connection to the broker.

Suggestion from fred@dushin.net.
