### PR TITLE
Set basic.qos.global = true to match broker behavior change.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - pushd _prereqs
   - git clone https://github.com/alanxz/rabbitmq-c
   - cd rabbitmq-c
-  - git checkout v0.4.1
+  - git checkout v0.5.1
   - export RABBITMQC_DIR=`pwd`/../../_install
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${RABBITMQC_DIR} -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .
   - cmake --build . --target install

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Known to work in the following environments:
 
 ### Pre-requisites
 +  [boost-1.47.0](http://www.boost.org/) or newer (uses chrono, system internally in addition to other header based libraries such as sharedptr and noncopyable)
-+  [rabbitmq-c](http://github.com/alanxz/rabbitmq-c) you'll need version 0.4.1 or better.
++  [rabbitmq-c](http://github.com/alanxz/rabbitmq-c) you'll need version 0.5.1 or better.
 +  [cmake 2.8+](http://www.cmake.org/) what is needed for the build system
 +  [Doxygen](http://www.stack.nl/~dimitri/doxygen/) OPTIONAL only necessary to generate API documentation
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -628,7 +628,7 @@ std::string Channel::BasicConsume(const std::string &queue,
     amqp_basic_qos_t qos = {};
     qos.prefetch_size = 0;
     qos.prefetch_count = message_prefetch_count;
-    qos.global = false;
+    qos.global = m_impl->BrokerHasNewQosBehavior();
 
     m_impl->DoRpcOnChannel(channel, AMQP_BASIC_QOS_METHOD, &qos, QOS_OK);
     m_impl->MaybeReleaseBuffersOnChannel(channel);
@@ -667,7 +667,7 @@ void Channel::BasicQos(const std::string &consumer_tag, boost::uint16_t message_
     amqp_basic_qos_t qos = {};
     qos.prefetch_size = 0;
     qos.prefetch_count = message_prefetch_count;
-    qos.global = false;
+    qos.global = m_impl->BrokerHasNewQosBehavior();
 
     m_impl->DoRpcOnChannel(channel, AMQP_BASIC_QOS_METHOD, &qos, QOS_OK);
     m_impl->MaybeReleaseBuffersOnChannel(channel);

--- a/src/SimpleAmqpClient/ChannelImpl.h
+++ b/src/SimpleAmqpClient/ChannelImpl.h
@@ -328,9 +328,20 @@ public:
         m_is_connected = state;
     }
 
+    // The RabbitMQ broker changed the way that basic.qos worked as of v3.2.0.
+    // See: http://www.rabbitmq.com/consumer-prefetch.html
+    // Newer versions of RabbitMQ basic.qos.global set to false applies to new
+    // consumers made on the channel, and true applies to all consumers on the
+    // channel (not connection).
+    bool BrokerHasNewQosBehavior() const {
+        return 0x030200 <= m_brokerVersion;
+    }
+
     amqp_connection_state_t m_connection;
 
 private:
+    static boost::uint32_t ComputeBrokerVersion(const amqp_connection_state_t state);
+
     frame_queue_t m_frame_queue;
 
     typedef std::vector<Envelope::ptr_t> envelope_list_t;
@@ -347,6 +358,7 @@ private:
     typedef std::vector<channel_state_t> channel_state_list_t;
 
     channel_state_list_t m_channels;
+    boost::uint32_t m_brokerVersion;
     // A channel that is likely to be an CS_Open state
     amqp_channel_t m_last_used_channel;
 

--- a/testing/test_consume.cpp
+++ b/testing/test_consume.cpp
@@ -103,12 +103,12 @@ TEST_F(connected_test, basic_consume_inital_qos)
 
     std::string consumer = channel->BasicConsume(queue, "", true, false);
     Envelope::ptr_t received1, received2;
-    ASSERT_TRUE(channel->BasicConsumeMessage(consumer, received1, 1));
+    ASSERT_TRUE(channel->BasicConsumeMessage(consumer, received1, 100));
 
-    EXPECT_FALSE(channel->BasicConsumeMessage(consumer, received2, 0));
+    EXPECT_FALSE(channel->BasicConsumeMessage(consumer, received2, 100));
     channel->BasicAck(received1);
 
-    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, received2, 1));
+    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, received2, 100));
 }
 
 TEST_F(connected_test, basic_consume_2consumers)
@@ -188,11 +188,11 @@ TEST_F(connected_test, basic_qos)
     channel->BasicPublish("", queue, BasicMessage::Create("Message2"));
 
     Envelope::ptr_t incoming;
-    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, incoming, 1));
-    EXPECT_FALSE(channel->BasicConsumeMessage(consumer, incoming, 1));
+    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, incoming, 100));
+    EXPECT_FALSE(channel->BasicConsumeMessage(consumer, incoming, 100));
 
     channel->BasicQos(consumer, 2);
-    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, incoming, 1));
+    EXPECT_TRUE(channel->BasicConsumeMessage(consumer, incoming, 100));
 
     channel->DeleteQueue(queue);
 }


### PR DESCRIPTION
The RabbitMQ broker changed the meaning of the global flag in the basic.qos
method in v3.2.0. (See: http://www.rabbitmq.com/consumer-prefetch.html)

Note that this fix needs some additional work to not break those using older versions of RabbitMQ.