### PR TITLE
Add ssl support to URI parser

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -90,6 +90,47 @@ Channel::ptr_t Channel::CreateFromUri(const std::string &uri, int frame_max)
                   frame_max);
 }
 
+Channel::ptr_t Channel::CreateFromUri(const std::string &uri,
+                                      const std::string &path_to_ca_cert,
+                                      const std::string &path_to_client_key,
+                                      const std::string &path_to_client_cert,
+                                      bool verify_hostname,
+                                      int frame_max)
+{
+    amqp_connection_info info;
+    amqp_default_connection_info(&info);
+
+    boost::shared_ptr<char> uri_dup = boost::shared_ptr<char>(strdup(uri.c_str()), free);
+
+    if (0 != amqp_parse_url(uri_dup.get(), &info))
+    {
+        throw BadUriException();
+    }
+
+    if ( info.ssl )
+    {
+        return CreateSecure(path_to_ca_cert,
+                      std::string(info.host),
+                      path_to_client_key,
+                      path_to_client_cert,
+                      info.port,
+                      std::string(info.user),
+                      std::string(info.password),
+                      std::string(info.vhost),
+                      frame_max,
+                      verify_hostname);
+    }
+    else
+    {
+        return Create(std::string(info.host),
+                      info.port,
+                      std::string(info.user),
+                      std::string(info.password),
+                      std::string(info.vhost),
+                      frame_max);
+    }
+}
+
 Channel::Channel(const std::string &host,
                  int port,
                  const std::string &username,

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -90,7 +90,7 @@ Channel::ptr_t Channel::CreateFromUri(const std::string &uri, int frame_max)
                   frame_max);
 }
 
-Channel::ptr_t Channel::CreateFromUri(const std::string &uri,
+Channel::ptr_t Channel::CreateSecureFromUri(const std::string &uri,
                                       const std::string &path_to_ca_cert,
                                       const std::string &path_to_client_key,
                                       const std::string &path_to_client_cert,
@@ -122,12 +122,7 @@ Channel::ptr_t Channel::CreateFromUri(const std::string &uri,
     }
     else
     {
-        return Create(std::string(info.host),
-                      info.port,
-                      std::string(info.user),
-                      std::string(info.password),
-                      std::string(info.vhost),
-                      frame_max);
+        throw std::runtime_error("CreateSecureFromUri only supports SSL-enabled URIs.");
     }
 }
 

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -161,9 +161,8 @@ public:
     static ptr_t CreateFromUri(const std::string &uri, int frame_max = 131072);
 
     /**
-     * Create a new Channel object from an AMQP URI, optionally secured with SSL
-     * If uri does not start with amqps, path_to_ca_cert, path_to_client_key, path_to_client_cert
-     * verify_hostname are ignored
+     * Create a new Channel object from an AMQP URI, secured with SSL.
+     * If URI should start with amqps://
      *
      * @param uri [in] a URI of the form: amqp[s]://[username:password@]{HOSTNAME}[:PORT][/VHOST]
      * @param path_to_ca_cert Path to ca certificate file
@@ -175,7 +174,7 @@ public:
      * * @param frame_max [in] requests that the broker limit the maximum size of any frame to this value
      * @returns a new Channel object
      */
-    static ptr_t CreateFromUri(const std::string &uri,
+    static ptr_t CreateSecureFromUri(const std::string &uri,
                                const std::string &path_to_ca_cert,
                                const std::string &path_to_client_key="",
                                const std::string &path_to_client_cert="",

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -160,6 +160,28 @@ public:
      */
     static ptr_t CreateFromUri(const std::string &uri, int frame_max = 131072);
 
+    /**
+     * Create a new Channel object from an AMQP URI, optionally secured with SSL
+     * If uri does not start with amqps, path_to_ca_cert, path_to_client_key, path_to_client_cert
+     * verify_hostname are ignored
+     *
+     * @param uri [in] a URI of the form: amqp[s]://[username:password@]{HOSTNAME}[:PORT][/VHOST]
+     * @param path_to_ca_cert Path to ca certificate file
+     * @param host The hostname or IP address of the AMQP broker
+     * @param path_to_client_key Path to client key file
+     * @param path_to_client_cert Path to client certificate file
+     * @param verify_hostname Verify the hostname against the certificate when
+     * opening the SSL connection.
+     * * @param frame_max [in] requests that the broker limit the maximum size of any frame to this value
+     * @returns a new Channel object
+     */
+    static ptr_t CreateFromUri(const std::string &uri,
+                               const std::string &path_to_ca_cert,
+                               const std::string &path_to_client_key="",
+                               const std::string &path_to_client_cert="",
+                               bool verify_hostname = true,
+                               int frame_max = 131072);
+
     explicit Channel(const std::string &host,
                      int port,
                      const std::string &username,


### PR DESCRIPTION
CreateFromURI method from Channel object does not currently handle SSL connections. This adds a new CreateFromURI that takes SSL parameters.