### PR TITLE
fix: several call on BasicConsume, always get the same channel

### DIFF
--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -149,7 +149,10 @@ amqp_channel_t ChannelImpl::GetChannel()
 
     if (m_channels.end() == it)
     {
-        return CreateNewChannel();
+        auto new_channel = CreateNewChannel();
+        m_last_used_channel = new_channel;
+        m_channels[new_channel] = CS_Used;
+        return new_channel;
     }
 
     *it = CS_Used;

--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -149,8 +149,7 @@ amqp_channel_t ChannelImpl::GetChannel()
 
     if (m_channels.end() == it)
     {
-        auto new_channel = CreateNewChannel();
-        m_last_used_channel = new_channel;
+        amqp_channel_t new_channel = CreateNewChannel();
         m_channels[new_channel] = CS_Used;
         return new_channel;
     }

--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -150,7 +150,7 @@ amqp_channel_t ChannelImpl::GetChannel()
     if (m_channels.end() == it)
     {
         amqp_channel_t new_channel = CreateNewChannel();
-        m_channels[new_channel] = CS_Used;
+        m_channels.at(new_channel) = CS_Used;
         return new_channel;
     }
 


### PR DESCRIPTION
```c++
 std::string tag_toto = this->channel->BasicConsume(queue_toto, "", no_local, no_ack); // <- OK
 std::string tag_titi = this->channel->BasicConsume(queue_titi, "", no_local, no_ack); // <- OK
 std::string tag_tata = this->channel->BasicConsume(queue_tata, "", no_local, no_ack); // <- KO
 std::string tag_tete = this->channel->BasicConsume(queue_tete, "", no_local, no_ack); // <- KO
```

After several call on BasicConsume, `Channel::GetChannel()` returns always the same channel.

This is because after calling `ChannelImpl::CreateNewChannel()`, the new channel is not registered as it should be.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/simpleamqpclient/115)
<!-- Reviewable:end -->
