### PR TITLE
CMake: fix MSVC build. add link to ws2_32.lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ endif ()
 INCLUDE_DIRECTORIES(BEFORE src
     ${CMAKE_CURRENT_BINARY_DIR})
 
+if (WIN32)
+    set(SOCKET_LIBRARY ws2_32)
+endif ()
+
 option(BUILD_SHARED_LIBS "Build SimpleAmqpClient as a shared library" ON)
 
 if (WIN32 AND NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
Fixes issue #107. 
Just reverting part of commit https://github.com/alanxz/SimpleAmqpClient/commit/431a8ce70b9ccc591736c493455cfbdda33eefb1.
Was tested on VS2015.