### PR TITLE
Add support for unsigned integer table values

### DIFF
--- a/src/SimpleAmqpClient/Table.h
+++ b/src/SimpleAmqpClient/Table.h
@@ -305,6 +305,10 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   /**
    * Get an integral number
    *
+   * Works for uint64 up to std::numeric_limits<int64_t>::max(),
+   * will throw a std::overflow_error otherwise. If the entire range
+   * of uint64_t is possible, please use GetUint64()
+   *
    * @returns an integer number if the ValueType is VT_uint8, VT_int8,
    * VT_uint16, VT_int16, VT_uint32, VT_int32, VT_uint64
    * or VT_int64 type, 0 otherwise

--- a/src/SimpleAmqpClient/Table.h
+++ b/src/SimpleAmqpClient/Table.h
@@ -90,7 +90,11 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
     VT_double = 7,  //< double-precision floating point type
     VT_string = 8,  //< string type
     VT_array = 9,   //< array of TableValues type
-    VT_table = 10   //< a table type
+    VT_table = 10,  //< a table type
+    VT_uint8 = 11,  //< 1-byte/char unsigned type
+    VT_uint16 = 12, //< 2-byte/short unsigned type
+    VT_uint32 = 13, //< 4-byte/int unsigned type
+    VT_uint64 = 14  //< 8-byte/long long int unsigned type
   };
 
   /**
@@ -108,11 +112,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   TableValue(bool value);
 
   /**
+   * Construct a 1-byte unsigned integer value
+   *
+   * @param value [in] the value
+   */
+  TableValue(boost::uint8_t value);
+
+  /**
    * Construct a 1-byte signed integer value
    *
    * @param value [in] the value
    */
   TableValue(boost::int8_t value);
+
+  /**
+   * Construct a 2-byte unsigned integer value
+   *
+   * @param value [in] the value
+   */
+  TableValue(boost::uint16_t value);
 
   /**
    * Construct a 2-byte signed integer value
@@ -122,11 +140,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   TableValue(boost::int16_t value);
 
   /**
+   * Construct a 4-byte unsigned integer value
+   *
+   * @param value [in] the value
+   */
+  TableValue(boost::uint32_t value);
+
+  /**
    * Construct a 4-byte signed integer value
    *
    * @param value [in] the value
    */
   TableValue(boost::int32_t value);
+
+  /**
+   * Construct a 8-byte unsigned integer value
+   *
+   * @param value [in] the value
+   */
+  TableValue(boost::uint64_t value);
 
   /**
    * Construct a 8-byte signed integer value
@@ -215,11 +247,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   bool GetBool() const;
 
   /**
+   * Get the uint8 value
+   *
+   * @returns the value if its a VT_uint8 type, 0 otherwise
+   */
+  boost::uint8_t GetUint8() const;
+
+  /**
    * Get the int8 value
    *
    * @returns the value if its a VT_int8 type, 0 otherwise
    */
   boost::int8_t GetInt8() const;
+
+  /**
+   * Get the uint16 value
+   *
+   * @returns the value if its a VT_uint16 type, 0 otherwise
+   */
+  boost::uint16_t GetUint16() const;
 
   /**
    * Get the int16 value
@@ -229,11 +275,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   boost::int16_t GetInt16() const;
 
   /**
+   * Get the uint32 value
+   *
+   * @returns the value if its a VT_uint32 type, 0 otherwise
+   */
+  boost::uint32_t GetUint32() const;
+
+  /**
    * Get the int32 value
    *
    * @returns the value if its a VT_int32 type, 0 otherwise
    */
   boost::int32_t GetInt32() const;
+
+  /**
+   * Get the uint64 value
+   *
+   * @returns the value if its a VT_uint64 type, 0 otherwise
+   */
+  boost::uint64_t GetUint64() const;
 
   /**
    * Get the int64 value
@@ -245,7 +305,8 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   /**
    * Get an integral number
    *
-   * @returns an integer number if the ValueType is VT_int8, VT_int16, VT_int32,
+   * @returns an integer number if the ValueType is VT_uint8, VT_int8,
+   * VT_uint16, VT_int16, VT_uint32, VT_int32, VT_uint64
    * or VT_int64 type, 0 otherwise
    */
   boost::int64_t GetInteger() const;
@@ -305,11 +366,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   void Set(bool value);
 
   /**
+   * Set the value as a uint8_t
+   *
+   * @param value [in] the value
+   */
+  void Set(boost::uint8_t value);
+
+  /**
    * Set the value as a int8_t
    *
    * @param value [in] the value
    */
   void Set(boost::int8_t value);
+
+  /**
+   * Set the value as a uint16_t
+   *
+   * @param value [in] the value
+   */
+  void Set(boost::uint16_t value);
 
   /**
    * Set the value as a int16_t
@@ -319,11 +394,25 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   void Set(boost::int16_t value);
 
   /**
+   * Set the value as a uint32_t
+   *
+   * @param value [in] the value
+   */
+  void Set(boost::uint32_t value);
+
+  /**
    * Set the value as a int32_t
    *
    * @param value [in] the value
    */
   void Set(boost::int32_t value);
+
+  /**
+   * Set teh value as a uint64_t
+   *
+   * @param value [in] the value
+   */
+  void Set(boost::uint64_t value);
 
   /**
    * Set teh value as a int64_t

--- a/src/SimpleAmqpClient/TableImpl.h
+++ b/src/SimpleAmqpClient/TableImpl.h
@@ -52,7 +52,8 @@ typedef std::vector<TableValue> array_t;
 
 typedef boost::variant<void_t, bool, boost::int8_t, boost::int16_t,
                        boost::int32_t, boost::int64_t, float, double,
-                       std::string, array_t, Table>
+                       std::string, array_t, Table, boost::uint8_t,
+                       boost::uint16_t, boost::uint32_t, boost::uint64_t>
     value_t;
 
 class TableValueImpl {
@@ -88,9 +89,13 @@ class TableValueImpl {
 
     amqp_field_value_t operator()(const void_t) const;
     amqp_field_value_t operator()(const bool value) const;
+    amqp_field_value_t operator()(const boost::uint8_t value) const;
     amqp_field_value_t operator()(const boost::int8_t value) const;
+    amqp_field_value_t operator()(const boost::uint16_t value) const;
     amqp_field_value_t operator()(const boost::int16_t value) const;
+    amqp_field_value_t operator()(const boost::uint32_t value) const;
     amqp_field_value_t operator()(const boost::int32_t value) const;
+    amqp_field_value_t operator()(const boost::uint64_t value) const;
     amqp_field_value_t operator()(const boost::int64_t value) const;
     amqp_field_value_t operator()(const float value) const;
     amqp_field_value_t operator()(const double value) const;

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -41,13 +41,25 @@ TableValue::TableValue()
 TableValue::TableValue(bool value)
     : m_impl(new Detail::TableValueImpl(value)) {}
 
+TableValue::TableValue(boost::uint8_t value)
+    : m_impl(new Detail::TableValueImpl(value)) {}
+
 TableValue::TableValue(boost::int8_t value)
+    : m_impl(new Detail::TableValueImpl(value)) {}
+
+TableValue::TableValue(boost::uint16_t value)
     : m_impl(new Detail::TableValueImpl(value)) {}
 
 TableValue::TableValue(boost::int16_t value)
     : m_impl(new Detail::TableValueImpl(value)) {}
 
+TableValue::TableValue(boost::uint32_t value)
+    : m_impl(new Detail::TableValueImpl(value)) {}
+
 TableValue::TableValue(boost::int32_t value)
+    : m_impl(new Detail::TableValueImpl(value)) {}
+
+TableValue::TableValue(boost::uint64_t value)
     : m_impl(new Detail::TableValueImpl(value)) {}
 
 TableValue::TableValue(boost::int64_t value)
@@ -120,18 +132,37 @@ TableValue::ValueType TableValue::GetType() const {
   return static_cast<ValueType>(m_impl->m_value.which());
 }
 
-bool TableValue::GetBool() const { return boost::get<bool>(m_impl->m_value); }
+bool TableValue::GetBool() const {
+  return boost::get<bool>(m_impl->m_value);
+}
+
+
+boost::uint8_t TableValue::GetUint8() const {
+  return boost::get<boost::uint8_t>(m_impl->m_value);
+}
 
 boost::int8_t TableValue::GetInt8() const {
   return boost::get<boost::int8_t>(m_impl->m_value);
+}
+
+boost::uint16_t TableValue::GetUint16() const {
+  return boost::get<boost::uint16_t>(m_impl->m_value);
 }
 
 boost::int16_t TableValue::GetInt16() const {
   return boost::get<boost::int16_t>(m_impl->m_value);
 }
 
+boost::uint32_t TableValue::GetUint32() const {
+  return boost::get<boost::uint32_t>(m_impl->m_value);
+}
+
 boost::int32_t TableValue::GetInt32() const {
   return boost::get<boost::int32_t>(m_impl->m_value);
+}
+
+boost::uint64_t TableValue::GetUint64() const {
+  return boost::get<boost::uint64_t>(m_impl->m_value);
 }
 
 boost::int64_t TableValue::GetInt64() const {
@@ -140,12 +171,20 @@ boost::int64_t TableValue::GetInt64() const {
 
 boost::int64_t TableValue::GetInteger() const {
   switch (m_impl->m_value.which()) {
+    case VT_uint8:
+      return GetUint8();
     case VT_int8:
       return GetInt8();
+    case VT_uint16:
+      return GetUint16();
     case VT_int16:
       return GetInt16();
+    case VT_uint32:
+      return GetUint32();
     case VT_int32:
       return GetInt32();
+    case VT_uint64:
+      return GetUint64();
     case VT_int64:
       return GetInt64();
     default:
@@ -188,11 +227,19 @@ void TableValue::Set() { m_impl->m_value = Detail::void_t(); }
 
 void TableValue::Set(bool value) { m_impl->m_value = value; }
 
+void TableValue::Set(boost::uint8_t value) { m_impl->m_value = value; }
+
 void TableValue::Set(boost::int8_t value) { m_impl->m_value = value; }
+
+void TableValue::Set(boost::uint16_t value) { m_impl->m_value = value; }
 
 void TableValue::Set(boost::int16_t value) { m_impl->m_value = value; }
 
+void TableValue::Set(boost::uint32_t value) { m_impl->m_value = value; }
+
 void TableValue::Set(boost::int32_t value) { m_impl->m_value = value; }
+
+void TableValue::Set(boost::uint64_t value) { m_impl->m_value = value; }
 
 void TableValue::Set(boost::int64_t value) { m_impl->m_value = value; }
 

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -184,7 +184,13 @@ boost::int64_t TableValue::GetInteger() const {
     case VT_int32:
       return GetInt32();
     case VT_uint64:
-      return GetUint64();
+    {
+      const boost::uint64_t value = GetUint64();
+      if (value > std::numeric_limits<int64_t>::max())
+        throw std::overflow_error(
+          "Result of GetUint64() is out of range.");
+      return value;
+    }
     case VT_int64:
       return GetInt64();
     default:

--- a/src/TableImpl.cpp
+++ b/src/TableImpl.cpp
@@ -66,10 +66,26 @@ amqp_field_value_t TableValueImpl::generate_field_value::operator()(
 }
 
 amqp_field_value_t TableValueImpl::generate_field_value::operator()(
+    const boost::uint8_t value) const {
+  amqp_field_value_t v;
+  v.kind = AMQP_FIELD_KIND_U8;
+  v.value.u8 = value;
+  return v;
+}
+
+amqp_field_value_t TableValueImpl::generate_field_value::operator()(
     const boost::int8_t value) const {
   amqp_field_value_t v;
   v.kind = AMQP_FIELD_KIND_I8;
   v.value.i8 = value;
+  return v;
+}
+
+amqp_field_value_t TableValueImpl::generate_field_value::operator()(
+    const boost::uint16_t value) const {
+  amqp_field_value_t v;
+  v.kind = AMQP_FIELD_KIND_U16;
+  v.value.u16 = value;
   return v;
 }
 
@@ -82,10 +98,26 @@ amqp_field_value_t TableValueImpl::generate_field_value::operator()(
 }
 
 amqp_field_value_t TableValueImpl::generate_field_value::operator()(
+    const boost::uint32_t value) const {
+  amqp_field_value_t v;
+  v.kind = AMQP_FIELD_KIND_U32;
+  v.value.u32 = value;
+  return v;
+}
+
+amqp_field_value_t TableValueImpl::generate_field_value::operator()(
     const boost::int32_t value) const {
   amqp_field_value_t v;
   v.kind = AMQP_FIELD_KIND_I32;
   v.value.i32 = value;
+  return v;
+}
+
+amqp_field_value_t TableValueImpl::generate_field_value::operator()(
+    const boost::uint64_t value) const {
+  amqp_field_value_t v;
+  v.kind = AMQP_FIELD_KIND_U64;
+  v.value.u64 = value;
   return v;
 }
 
@@ -217,12 +249,20 @@ TableValue TableValueImpl::CreateTableValue(const amqp_field_value_t &entry) {
       return TableValue();
     case AMQP_FIELD_KIND_BOOLEAN:
       return TableValue((bool)entry.value.boolean);
+    case AMQP_FIELD_KIND_U8:
+      return TableValue(entry.value.u8);
     case AMQP_FIELD_KIND_I8:
       return TableValue(entry.value.i8);
+    case AMQP_FIELD_KIND_U16:
+      return TableValue(entry.value.u16);
     case AMQP_FIELD_KIND_I16:
       return TableValue(entry.value.i16);
+    case AMQP_FIELD_KIND_U32:
+      return TableValue(entry.value.u32);
     case AMQP_FIELD_KIND_I32:
       return TableValue(entry.value.i32);
+    case AMQP_FIELD_KIND_U64:
+      return TableValue(entry.value.u64);
     case AMQP_FIELD_KIND_I64:
     case AMQP_FIELD_KIND_TIMESTAMP:
       return TableValue(entry.value.i64);

--- a/testing/test_table.cpp
+++ b/testing/test_table.cpp
@@ -436,6 +436,52 @@ TEST(table_value, uint64_value) {
   EXPECT_THROW(value.GetTable(), boost::bad_get);
 }
 
+TEST(table_value, uint64_value_larger_than_int64_max) {
+  const boost::uint64_t maxInt64 = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  boost::uint64_t v1 = maxInt64 + 1;
+  boost::uint64_t v2 = maxInt64 + 2;
+
+  TableValue value(v1);
+  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
+  EXPECT_EQ(v1, value.GetUint64());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetInteger(), std::overflow_error);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+
+  value.Set(v2);
+  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
+  EXPECT_EQ(v2, value.GetUint64());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetInteger(), std::overflow_error);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+}
+
 TEST(table_value, int64_value) {
   boost::int64_t v1 = 1;
   boost::int64_t v2 = 2;

--- a/testing/test_table.cpp
+++ b/testing/test_table.cpp
@@ -39,9 +39,13 @@ TEST(table_value, void_value) {
   EXPECT_EQ(TableValue::VT_void, value.GetType());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -55,9 +59,13 @@ TEST(table_value, void_value) {
   EXPECT_EQ(TableValue::VT_void, value.GetType());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -76,9 +84,13 @@ TEST(table_value, bool_value) {
   EXPECT_EQ(TableValue::VT_bool, value.GetType());
 
   EXPECT_EQ(v1, value.GetBool());
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -92,11 +104,60 @@ TEST(table_value, bool_value) {
   EXPECT_EQ(TableValue::VT_bool, value.GetType());
 
   EXPECT_EQ(v2, value.GetBool());
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+}
+
+TEST(table_value, uint8_value) {
+  boost::uint8_t v1 = 1;
+  boost::uint8_t v2 = 2;
+
+  TableValue value(v1);
+  EXPECT_EQ(TableValue::VT_uint8, value.GetType());
+  EXPECT_EQ(v1, value.GetUint8());
+  EXPECT_EQ(v1, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+
+  value.Set(v2);
+  EXPECT_EQ(TableValue::VT_uint8, value.GetType());
+  EXPECT_EQ(v2, value.GetUint8());
+  EXPECT_EQ(v2, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -115,8 +176,12 @@ TEST(table_value, int8_value) {
   EXPECT_EQ(v1, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -131,8 +196,57 @@ TEST(table_value, int8_value) {
   EXPECT_EQ(v2, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+}
+
+TEST(table_value, uint16_value) {
+  boost::uint16_t v1 = 1;
+  boost::uint16_t v2 = 2;
+
+  TableValue value(v1);
+  EXPECT_EQ(TableValue::VT_uint16, value.GetType());
+  EXPECT_EQ(v1, value.GetUint16());
+  EXPECT_EQ(v1, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+
+  value.Set(v2);
+  EXPECT_EQ(TableValue::VT_uint16, value.GetType());
+  EXPECT_EQ(v2, value.GetUint16());
+  EXPECT_EQ(v2, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -152,8 +266,12 @@ TEST(table_value, int16_value) {
   EXPECT_EQ(v1, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -168,8 +286,57 @@ TEST(table_value, int16_value) {
   EXPECT_EQ(v2, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+}
+
+TEST(table_value, uint32_value) {
+  boost::uint32_t v1 = 1;
+  boost::uint32_t v2 = 2;
+
+  TableValue value(v1);
+  EXPECT_EQ(TableValue::VT_uint32, value.GetType());
+  EXPECT_EQ(v1, value.GetUint32());
+  EXPECT_EQ(v1, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+
+  value.Set(v2);
+  EXPECT_EQ(TableValue::VT_uint32, value.GetType());
+  EXPECT_EQ(v2, value.GetUint32());
+  EXPECT_EQ(v2, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -189,8 +356,12 @@ TEST(table_value, int32_value) {
   EXPECT_EQ(v1, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -205,8 +376,57 @@ TEST(table_value, int32_value) {
   EXPECT_EQ(v2, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+}
+
+TEST(table_value, uint64_value) {
+  boost::uint64_t v1 = 1;
+  boost::uint64_t v2 = 2;
+
+  TableValue value(v1);
+  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
+  EXPECT_EQ(v1, value.GetUint64());
+  EXPECT_EQ(v1, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetFloat(), boost::bad_get);
+  EXPECT_THROW(value.GetDouble(), boost::bad_get);
+  EXPECT_THROW(value.GetReal(), boost::bad_get);
+  EXPECT_THROW(value.GetString(), boost::bad_get);
+  EXPECT_THROW(value.GetArray(), boost::bad_get);
+  EXPECT_THROW(value.GetTable(), boost::bad_get);
+
+  value.Set(v2);
+  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
+  EXPECT_EQ(v2, value.GetUint64());
+  EXPECT_EQ(v2, value.GetInteger());
+
+  EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
+  EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
+  EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
+  EXPECT_THROW(value.GetInt32(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -226,9 +446,13 @@ TEST(table_value, int64_value) {
   EXPECT_EQ(v1, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -242,9 +466,13 @@ TEST(table_value, int64_value) {
   EXPECT_EQ(v2, value.GetInteger());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -263,9 +491,13 @@ TEST(table_value, float_value) {
   EXPECT_EQ(v1, value.GetReal());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -279,9 +511,13 @@ TEST(table_value, float_value) {
   EXPECT_EQ(v2, value.GetReal());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -300,9 +536,13 @@ TEST(table_value, double_value) {
   EXPECT_EQ(v1, value.GetReal());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -316,9 +556,13 @@ TEST(table_value, double_value) {
   EXPECT_EQ(v2, value.GetReal());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -336,9 +580,13 @@ TEST(table_value, string_value) {
   EXPECT_EQ(v1, value.GetString());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -352,9 +600,13 @@ TEST(table_value, string_value) {
   EXPECT_EQ(v2, value.GetString());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -378,9 +630,13 @@ TEST(table_value, array_value) {
   EXPECT_TRUE(std::equal(v1.begin(), v1.end(), v1a.begin()));
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -396,9 +652,13 @@ TEST(table_value, array_value) {
   EXPECT_TRUE(std::equal(v2.begin(), v2.end(), v2a.begin()));
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -422,9 +682,13 @@ TEST(table_value, table_value) {
   EXPECT_TRUE(std::equal(v1.begin(), v1.end(), v1a.begin()));
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -440,9 +704,13 @@ TEST(table_value, table_value) {
   EXPECT_TRUE(std::equal(v2.begin(), v2.end(), v2a.begin()));
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
+  EXPECT_THROW(value.GetUint8(), boost::bad_get);
   EXPECT_THROW(value.GetInt8(), boost::bad_get);
+  EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
+  EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
+  EXPECT_THROW(value.GetUint64(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -518,9 +786,13 @@ TEST(table, convert_to_rabbitmq) {
   Table table_in;
   table_in.insert(TableEntry("void_key", TableValue()));
   table_in.insert(TableEntry("bool_key", true));
+  table_in.insert(TableEntry("uint8_key", uint8_t(8)));
   table_in.insert(TableEntry("int8_key", int8_t(8)));
+  table_in.insert(TableEntry("uint16_key", uint16_t(16)));
   table_in.insert(TableEntry("int16_key", int16_t(16)));
+  table_in.insert(TableEntry("uint32_key", uint32_t(32)));
   table_in.insert(TableEntry("int32_key", int32_t(32)));
+  table_in.insert(TableEntry("uint64_key", uint64_t(64)));
   table_in.insert(TableEntry("int64_key", int64_t(64)));
   table_in.insert(TableEntry("float_key", float(1.5)));
   table_in.insert(TableEntry("double_key", double(2.25)));
@@ -562,9 +834,13 @@ TEST_F(connected_test, basic_message_header_roundtrip) {
   Table table_in;
   table_in.insert(TableEntry("void_key", TableValue()));
   table_in.insert(TableEntry("bool_key", true));
+  table_in.insert(TableEntry("uint8_key", uint8_t(8)));
   table_in.insert(TableEntry("int8_key", int8_t(8)));
+  table_in.insert(TableEntry("uint16_key", uint16_t(16)));
   table_in.insert(TableEntry("int16_key", int16_t(16)));
+  table_in.insert(TableEntry("uint32_key", uint32_t(32)));
   table_in.insert(TableEntry("int32_key", int32_t(32)));
+  table_in.insert(TableEntry("uint64_key", uint64_t(64)));
   table_in.insert(TableEntry("int64_key", int64_t(64)));
   table_in.insert(TableEntry("float_key", float(1.5)));
   table_in.insert(TableEntry("double_key", double(2.25)));


### PR DESCRIPTION
This adds support for the unsigned counterparty of integer types already supported as `TableValue`, namely: `uint8_t`, `uint16_t`, `uint32_t` and `uint64_t`.

The corresponding tests have also been added and the existing tests have been updated accordingly.