### PR TITLE
Made the heartbeat interval a configurable property of the channel

### DIFF
--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -51,7 +51,6 @@
 
 #include <string.h>
 
-#define BROKER_HEARTBEAT 0
 
 namespace AmqpClient {
 namespace Detail {
@@ -64,7 +63,7 @@ ChannelImpl::~ChannelImpl() {}
 
 void ChannelImpl::DoLogin(const std::string &username,
                           const std::string &password, const std::string &vhost,
-                          int frame_max) {
+                          int frame_max, int heartbeat) {
   amqp_table_entry_t capabilties[1];
   amqp_table_entry_t capability_entry;
   amqp_table_t client_properties;
@@ -84,7 +83,7 @@ void ChannelImpl::DoLogin(const std::string &username,
 
   CheckRpcReply(
       0, amqp_login_with_properties(m_connection, vhost.c_str(), 0, frame_max,
-                                    BROKER_HEARTBEAT, &client_properties,
+                                    heartbeat, &client_properties,
                                     AMQP_SASL_METHOD_PLAIN, username.c_str(),
                                     password.c_str()));
 

--- a/src/SimpleAmqpClient/ChannelImpl.h
+++ b/src/SimpleAmqpClient/ChannelImpl.h
@@ -60,7 +60,7 @@ class ChannelImpl : boost::noncopyable {
   typedef channel_map_t::iterator channel_map_iterator_t;
 
   void DoLogin(const std::string &username, const std::string &password,
-               const std::string &vhost, int frame_max);
+               const std::string &vhost, int frame_max, int heartbeat);
   amqp_channel_t GetChannel();
   void ReturnChannel(amqp_channel_t channel);
   bool IsChannelOpen(amqp_channel_t channel);


### PR DESCRIPTION
This pull request fixes #169 . The heartbeat interval can be specified upon creation of the channel.  Heartbeats are disabled if not explicitly specified.