### PR TITLE
Wrap amqp_get_sockfd() to expose the connection socket FD

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -200,7 +200,7 @@ Channel::~Channel() {
   amqp_destroy_connection(m_impl->m_connection);
 }
 
-int Channel::GetSocketFD() {
+int Channel::GetSocketFD() const {
   return amqp_get_sockfd(m_impl->m_connection);
 }
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -200,6 +200,10 @@ Channel::~Channel() {
   amqp_destroy_connection(m_impl->m_connection);
 }
 
+int Channel::GetSocketFD() {
+  return amqp_get_sockfd(m_impl->m_connection);
+}
+
 void Channel::DeclareExchange(const std::string &exchange_name,
                               const std::string &exchange_type, bool passive,
                               bool durable, bool auto_delete) {

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -192,6 +192,12 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
   virtual ~Channel();
 
   /**
+    * Exposes the underlying socket handle
+    * @returns file descriptor number associated with the connection socket
+    */
+  int GetSocketFD() const;
+
+  /**
     * Declares an exchange
     * Creates an exchange on the AMQP broker if it does not already exist
     * @param exchange_name the name of the exchange

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -194,6 +194,13 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
   /**
     * Exposes the underlying socket handle
     * @returns file descriptor number associated with the connection socket
+    *
+    * @warning This function exposes an internal implementation detail
+    * of SimpleAmqpClient. Manipulating the socket descriptor will result in
+    * undefined behavior of the library. Additionally SimpleAmqpClient's use of
+    * the socket will change depending on what version of rabbitmq-c and
+    * SimpleAmqpClient are used. Test carefully before depending on any specific
+    * behavior.
     */
   int GetSocketFD() const;
 


### PR DESCRIPTION
Hi!

Our team currently maintains an internal version of `SimpleAmqpClient` with a "patch" which essentially boils down to what I'm sending here.

In one paragraph, we need to integrate RabbitMQ consumers with other network services (servers and clients) so that they run together in a single process. This is typically done via the event loop a.k.a. reactor pattern; to get that to work, we must have a way to obtain every connection's file descriptor (FD).

This team is not really that familiar with Open Source and shies away from contributing. So what they did was just package up a version of the library which **includes `ChannelImpl.h`** in the published/installable header set; and use that in their apps to obtain the file descriptor through direct access to `m_impl->m_connection`. As anyone can see, this is suboptimal, both architecturally and maintenance-burden-wise. 

I figured, many users might benefit from this little extension to the public API, so here you go.
