### PR TITLE
compilation fix

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -187,7 +187,7 @@ Channel::Channel(const std::string &host, int port, const std::string &username,
 #else
 Channel::Channel(const std::string &, int, const std::string &,
                  const std::string &, const std::string &, int,
-                 const SSLConnectionParams &) {
+                 const SSLConnectionParams &, bool) {
   throw std::logic_error(
       "SSL support has not been compiled into SimpleAmqpClient");
 }


### PR DESCRIPTION
Fixes https://github.com/alanxz/SimpleAmqpClient/issues/238
Compilation without SSL support is broken due to wrong method signature.
Bug comes from https://github.com/alanxz/SimpleAmqpClient/commit/56713c06e273a4869332391164eed8a0f7137cac commit.