### PR TITLE
lib: add support for rejected message in publish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SAC_LIB_SRCS
     src/SimpleAmqpClient/BadUriException.h
     src/SimpleAmqpClient/ConnectionClosedException.h
     src/SimpleAmqpClient/ConsumerTagNotFoundException.h
+    src/SimpleAmqpClient/MessageRejectedException.h
 
     src/SimpleAmqpClient/Envelope.h
     src/Envelope.cpp
@@ -183,6 +184,7 @@ install(FILES
     src/SimpleAmqpClient/ConsumerTagNotFoundException.h
     src/SimpleAmqpClient/Envelope.h
     src/SimpleAmqpClient/MessageReturnedException.h
+    src/SimpleAmqpClient/MessageRejectedException.h
     src/SimpleAmqpClient/SimpleAmqpClient.h
     src/SimpleAmqpClient/Table.h
     src/SimpleAmqpClient/Util.h

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -55,6 +55,7 @@
 #include "SimpleAmqpClient/ChannelImpl.h"
 #include "SimpleAmqpClient/ConsumerCancelledException.h"
 #include "SimpleAmqpClient/ConsumerTagNotFoundException.h"
+#include "SimpleAmqpClient/MessageRejectedException.h"
 #include "SimpleAmqpClient/MessageReturnedException.h"
 #include "SimpleAmqpClient/TableImpl.h"
 #include "SimpleAmqpClient/Util.h"
@@ -522,16 +523,28 @@ void Channel::BasicPublish(const std::string &exchange_name,
   // broker
   // - basic.ack - our channel is in confirm mode, messsage was 'dealt with' by
   // the broker
+  // - basic.nack - our channel is in confirm mode, queue has max-length set and
+  // is full, queue overflow stratege is reject-publish
   // - basic.return then basic.ack - the message wasn't delievered, but was
   // dealt with
   // - channel.close - probably tried to publish to a non-existant exchange, in
   // any case error!
   // - connection.clsoe - something really bad happened
-  const boost::array<boost::uint32_t, 2> PUBLISH_ACK = {
-      {AMQP_BASIC_ACK_METHOD, AMQP_BASIC_RETURN_METHOD}};
+  const boost::array<boost::uint32_t, 3> PUBLISH_ACK = {
+      {AMQP_BASIC_ACK_METHOD, AMQP_BASIC_RETURN_METHOD,
+       AMQP_BASIC_NACK_METHOD}};
   amqp_frame_t response;
   boost::array<amqp_channel_t, 1> channels = {{channel}};
   m_impl->GetMethodOnChannel(channels, response, PUBLISH_ACK);
+
+  if (AMQP_BASIC_NACK_METHOD == response.payload.method.id) {
+    amqp_basic_nack_t *return_method =
+        reinterpret_cast<amqp_basic_nack_t *>(response.payload.method.decoded);
+    MessageRejectedException message_rejected(return_method->delivery_tag);
+    m_impl->ReturnChannel(channel);
+    m_impl->MaybeReleaseBuffersOnChannel(channel);
+    throw message_rejected;
+  }
 
   if (AMQP_BASIC_RETURN_METHOD == response.payload.method.id) {
     MessageReturnedException message_returned =

--- a/src/SimpleAmqpClient/MessageRejectedException.h
+++ b/src/SimpleAmqpClient/MessageRejectedException.h
@@ -1,5 +1,5 @@
-#ifndef SIMPLEAMQPCLIENT_SIMPLEAMQPCLIENT_H
-#define SIMPLEAMQPCLIENT_SIMPLEAMQPCLIENT_H
+#ifndef SIMPLEAMQPCLIENT_MESSAGEREJECTEDEXCEPTION_H
+#define SIMPLEAMQPCLIENT_MESSAGEREJECTEDEXCEPTION_H
 /*
  * ***** BEGIN LICENSE BLOCK *****
  * Version: MIT
@@ -28,16 +28,38 @@
  * ***** END LICENSE BLOCK *****
  */
 
-#include "SimpleAmqpClient/AmqpException.h"
-#include "SimpleAmqpClient/AmqpResponseLibraryException.h"
-#include "SimpleAmqpClient/BasicMessage.h"
-#include "SimpleAmqpClient/Channel.h"
-#include "SimpleAmqpClient/ConnectionClosedException.h"
-#include "SimpleAmqpClient/ConsumerCancelledException.h"
-#include "SimpleAmqpClient/ConsumerTagNotFoundException.h"
-#include "SimpleAmqpClient/Envelope.h"
-#include "SimpleAmqpClient/MessageReturnedException.h"
-#include "SimpleAmqpClient/MessageRejectedException.h"
-#include "SimpleAmqpClient/Version.h"
+#include <boost/cstdint.hpp>
+#include <boost/lexical_cast.hpp>
+#include <stdexcept>
 
-#endif  // SIMPLEAMQPCLIENT_SIMPLEAMQPCLIENT_H
+#include "SimpleAmqpClient/BasicMessage.h"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251 4275)
+#endif
+
+namespace AmqpClient {
+
+class SIMPLEAMQPCLIENT_EXPORT MessageRejectedException
+    : public std::runtime_error {
+ public:
+  MessageRejectedException(uint64_t delivery_tag)
+      : std::runtime_error(
+            std::string("Message rejected: ")
+                .append(boost::lexical_cast<std::string>(delivery_tag))),
+        m_delivery_tag(delivery_tag) {}
+
+  uint64_t GetDeliverTag() { return m_delivery_tag; }
+
+ private:
+  uint64_t m_delivery_tag;
+};
+
+}  // namespace AmqpClient
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#endif  // SIMPLEAMQPCLIENT_MESSAGEREJECTEDEXCEPTION_H

--- a/testing/test_channels.cpp
+++ b/testing/test_channels.cpp
@@ -80,6 +80,19 @@ TEST_F(connected_test, channel_publish_returned_mandatory) {
       MessageReturnedException);
 }
 
+TEST_F(connected_test, channel_publish_full_rejected) {
+  BasicMessage::ptr_t message = BasicMessage::Create("Test message");
+  Table args;
+  args.insert(TableEntry("x-max-length", 0));
+  args.insert(TableEntry("x-overflow", "reject-publish"));
+  std::string queue = channel->DeclareQueue("", false , false,
+                                            true, true, args);
+
+  EXPECT_THROW(
+      channel->BasicPublish("", queue, message),
+      MessageRejectedException);
+}
+
 TEST_F(connected_test, DISABLED_channel_publish_returned_immediate) {
   BasicMessage::ptr_t message = BasicMessage::Create("Test message");
   std::string queue_name = channel->DeclareQueue("");


### PR DESCRIPTION
This effectively adds support for the broker to reject messages when a
queue is full. See https://www.rabbitmq.com/maxlength.html for an exmple
use case.

Fixes #215
Fixes #245

Fixes #216 