### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 language: cpp
 
-dist: trusty
+dist: xenial
 sudo: true
 
 compiler:
@@ -17,6 +17,11 @@ env:
    - secure: "Fbs306tCqDrDZTEwTE4ZvQ9Jb1BRbGNMgdkDy4G+EY02tuuxHFOh0Dm9N5ylVEzOcMZUpYLogh5HDpXtvVB71hmkphfDodqdinNAmalsWzg/lOx4x414/WMyo6/vT7X+qxHmLpt/XuLVSSBP7u96hg3+/3QOhQ/x2cBMI4eAMqg="
 
 addons:
+  apt:
+    packages:
+      - libboost-dev
+      - libboost-chrono-dev
+      - libboost-system-dev
   coverity_scan:
     project:
       name: "alanxz/SimpleAmqpClient"
@@ -28,8 +33,6 @@ addons:
 
 # install pre-reqs
 install:
-  - sudo apt-get update
-  - sudo apt-get install libboost1.55-dev libboost-chrono1.55-dev libboost-system1.55-dev
   - mkdir -p _prereqs
   - pushd _prereqs
   - git clone https://github.com/alanxz/rabbitmq-c

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - pushd _prereqs
   - git clone https://github.com/alanxz/rabbitmq-c
   - cd rabbitmq-c
-  - git checkout v0.8.0
+  - git checkout v0.10.0
   - export RABBITMQC_DIR=`pwd`/../../_install
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${RABBITMQC_DIR} -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TOOLS=OFF .
   - cmake --build . --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
-cmake_minimum_required(VERSION 2.8)
+# Most widely used distributions have cmake 3.5 or greater available as of March
+# 2019.  A notable exception is RHEL-7 (CentOS7).  You can install a current
+# version of CMake by first installing Extra Packages for Enterprise Linux
+# (https://fedoraproject.org/wiki/EPEL#Extra_Packages_for_Enterprise_Linux_.28EPEL.29)
+# and then issuing `yum install cmake3` on the command line.
+cmake_minimum_required(VERSION 3.5)
 
-project(SimpleAmqpClient)
+project(SimpleAmqpClient LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Follow all steps below in order to calculate new ABI version when updating the library
 # NOTE: THIS IS UNRELATED to the actual project version

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -29,6 +29,7 @@
 #include "SimpleAmqpClient/Table.h"
 
 #include <algorithm>
+#include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
 #include <iterator>
 #include <limits>

--- a/testing/test_table.cpp
+++ b/testing/test_table.cpp
@@ -27,6 +27,7 @@
  */
 
 #include <algorithm>
+#include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
 
 #include "connected_test.h"


### PR DESCRIPTION
* Update to supported linux distribution (xenial)
* Add workaround for boost v1.58.0 brokenness with variant
* Make CMake specify c++98 as a standard when building