### PR TITLE
lib: refactor BasicMessage removing rabbitmq-c API

### DIFF
--- a/src/BasicMessage.cpp
+++ b/src/BasicMessage.cpp
@@ -32,429 +32,284 @@
 #include <amqp.h>
 #include <amqp_framing.h>
 
+#include <boost/optional/optional.hpp>
 #include <cstring>
+#include <string>
 
 #include "SimpleAmqpClient/TableImpl.h"
 
 namespace AmqpClient {
 
-namespace Detail {
-
-class BasicMessageImpl {
- public:
-  BasicMessageImpl() : m_properties(), m_body() {}
-  amqp_basic_properties_t m_properties;
-  amqp_bytes_t m_body;
-  amqp_pool_ptr_t m_table_pool;
+struct BasicMessage::Impl {
+  std::string body;
+  boost::optional<std::string> content_type;
+  boost::optional<std::string> content_encoding;
+  boost::optional<delivery_mode_t> delivery_mode;
+  boost::optional<boost::uint8_t> priority;
+  boost::optional<std::string> correlation_id;
+  boost::optional<std::string> reply_to;
+  boost::optional<std::string> expiration;
+  boost::optional<std::string> message_id;
+  boost::optional<boost::uint64_t> timestamp;
+  boost::optional<std::string> type;
+  boost::optional<std::string> user_id;
+  boost::optional<std::string> app_id;
+  boost::optional<std::string> cluster_id;
+  boost::optional<Table> header_table;
 };
-}  // namespace Detail
 
-BasicMessage::BasicMessage() : m_impl(new Detail::BasicMessageImpl) {
-  m_impl->m_body.bytes = NULL;
-  m_impl->m_body.len = 0;
-  m_impl->m_properties._flags = 0;
-}
+BasicMessage::BasicMessage() : m_impl(new Impl) {}
 
-BasicMessage::BasicMessage(const std::string &body)
-    : m_impl(new Detail::BasicMessageImpl) {
+BasicMessage::BasicMessage(const std::string& body) : m_impl(new Impl) {
   Body(body);
-  m_impl->m_properties._flags = 0;
 }
 
-BasicMessage::BasicMessage(const amqp_bytes_t &body,
-                           const amqp_basic_properties_t *properties)
-    : m_impl(new Detail::BasicMessageImpl) {
-  m_impl->m_body = body;
-  m_impl->m_properties = *properties;
-  if (ContentTypeIsSet())
-    m_impl->m_properties.content_type =
-        amqp_bytes_malloc_dup(m_impl->m_properties.content_type);
-  if (ContentEncodingIsSet())
-    m_impl->m_properties.content_encoding =
-        amqp_bytes_malloc_dup(m_impl->m_properties.content_encoding);
-  if (CorrelationIdIsSet())
-    m_impl->m_properties.correlation_id =
-        amqp_bytes_malloc_dup(m_impl->m_properties.correlation_id);
-  if (ReplyToIsSet())
-    m_impl->m_properties.reply_to =
-        amqp_bytes_malloc_dup(m_impl->m_properties.reply_to);
-  if (ExpirationIsSet())
-    m_impl->m_properties.expiration =
-        amqp_bytes_malloc_dup(m_impl->m_properties.expiration);
-  if (MessageIdIsSet())
-    m_impl->m_properties.message_id =
-        amqp_bytes_malloc_dup(m_impl->m_properties.message_id);
-  if (TypeIsSet())
-    m_impl->m_properties.type =
-        amqp_bytes_malloc_dup(m_impl->m_properties.type);
-  if (UserIdIsSet())
-    m_impl->m_properties.user_id =
-        amqp_bytes_malloc_dup(m_impl->m_properties.user_id);
-  if (AppIdIsSet())
-    m_impl->m_properties.app_id =
-        amqp_bytes_malloc_dup(m_impl->m_properties.app_id);
-  if (ClusterIdIsSet())
-    m_impl->m_properties.cluster_id =
-        amqp_bytes_malloc_dup(m_impl->m_properties.cluster_id);
-  if (HeaderTableIsSet())
-    m_impl->m_properties.headers = Detail::TableValueImpl::CopyTable(
-        m_impl->m_properties.headers, m_impl->m_table_pool);
-}
+BasicMessage::~BasicMessage() {}
 
-BasicMessage::~BasicMessage() {
-  amqp_bytes_free(m_impl->m_body);
-  if (ContentTypeIsSet()) amqp_bytes_free(m_impl->m_properties.content_type);
-  if (ContentEncodingIsSet())
-    amqp_bytes_free(m_impl->m_properties.content_encoding);
-  if (CorrelationIdIsSet())
-    amqp_bytes_free(m_impl->m_properties.correlation_id);
-  if (ReplyToIsSet()) amqp_bytes_free(m_impl->m_properties.reply_to);
-  if (ExpirationIsSet()) amqp_bytes_free(m_impl->m_properties.expiration);
-  if (MessageIdIsSet()) amqp_bytes_free(m_impl->m_properties.message_id);
-  if (TypeIsSet()) amqp_bytes_free(m_impl->m_properties.type);
-  if (UserIdIsSet()) amqp_bytes_free(m_impl->m_properties.user_id);
-  if (AppIdIsSet()) amqp_bytes_free(m_impl->m_properties.app_id);
-  if (ClusterIdIsSet()) amqp_bytes_free(m_impl->m_properties.cluster_id);
-}
+const std::string& BasicMessage::Body() const { return m_impl->body; }
 
-const amqp_basic_properties_t *BasicMessage::getAmqpProperties() const {
-  return &m_impl->m_properties;
-}
+std::string& BasicMessage::Body() { return m_impl->body; }
 
-const amqp_bytes_t &BasicMessage::getAmqpBody() const { return m_impl->m_body; }
+void BasicMessage::Body(const std::string& body) { m_impl->body = body; }
 
-std::string BasicMessage::Body() const {
-  if (m_impl->m_body.bytes == NULL) return std::string();
-  return std::string((char *)m_impl->m_body.bytes, m_impl->m_body.len);
-}
-void BasicMessage::Body(const std::string &body) {
-  if (NULL != m_impl->m_body.bytes) {
-    amqp_bytes_free(m_impl->m_body);
+const std::string& BasicMessage::ContentType() const {
+  if (ContentTypeIsSet()) {
+    return m_impl->content_type.value();
   }
-  amqp_bytes_t body_bytes;
-  body_bytes.bytes = const_cast<char *>(body.data());
-  body_bytes.len = body.length();
-  m_impl->m_body = amqp_bytes_malloc_dup(body_bytes);
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::ContentType() const {
-  if (ContentTypeIsSet())
-    return std::string((char *)m_impl->m_properties.content_type.bytes,
-                       m_impl->m_properties.content_type.len);
-  return std::string();
-}
-
-void BasicMessage::ContentType(const std::string &content_type) {
-  if (ContentTypeIsSet()) amqp_bytes_free(m_impl->m_properties.content_type);
-  m_impl->m_properties.content_type =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(content_type.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_CONTENT_TYPE_FLAG;
+void BasicMessage::ContentType(const std::string& content_type) {
+  m_impl->content_type = content_type;
 }
 
 bool BasicMessage::ContentTypeIsSet() const {
-  return AMQP_BASIC_CONTENT_TYPE_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_CONTENT_TYPE_FLAG);
+  return m_impl->content_type.is_initialized();
 }
 
-void BasicMessage::ContentTypeClear() {
-  if (ContentTypeIsSet()) amqp_bytes_free(m_impl->m_properties.content_type);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_CONTENT_TYPE_FLAG;
+void BasicMessage::ContentTypeClear() { m_impl->content_type.reset(); }
+
+const std::string& BasicMessage::ContentEncoding() const {
+  if (ContentEncodingIsSet()) {
+    return m_impl->content_encoding.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::ContentEncoding() const {
-  if (ContentEncodingIsSet())
-    return std::string((char *)m_impl->m_properties.content_encoding.bytes,
-                       m_impl->m_properties.content_encoding.len);
-  return std::string();
-}
-
-void BasicMessage::ContentEncoding(const std::string &content_encoding) {
-  if (ContentEncodingIsSet())
-    amqp_bytes_free(m_impl->m_properties.content_encoding);
-  m_impl->m_properties.content_encoding =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(content_encoding.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_CONTENT_ENCODING_FLAG;
+void BasicMessage::ContentEncoding(const std::string& content_encoding) {
+  m_impl->content_encoding = content_encoding;
 }
 
 bool BasicMessage::ContentEncodingIsSet() const {
-  return AMQP_BASIC_CONTENT_ENCODING_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_CONTENT_ENCODING_FLAG);
+  return m_impl->content_encoding.is_initialized();
 }
 
-void BasicMessage::ContentEncodingClear() {
-  if (ContentEncodingIsSet())
-    amqp_bytes_free(m_impl->m_properties.content_encoding);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_CONTENT_ENCODING_FLAG;
-}
+void BasicMessage::ContentEncodingClear() { m_impl->content_encoding.reset(); }
 
 BasicMessage::delivery_mode_t BasicMessage::DeliveryMode() const {
-  if (DeliveryModeIsSet())
-    return (delivery_mode_t)m_impl->m_properties.delivery_mode;
-  return (delivery_mode_t)0;
+  return m_impl->delivery_mode.value_or(dm_notset);
 }
 
 void BasicMessage::DeliveryMode(delivery_mode_t delivery_mode) {
-  m_impl->m_properties.delivery_mode = static_cast<uint8_t>(delivery_mode);
-  m_impl->m_properties._flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
+  m_impl->delivery_mode = delivery_mode;
 }
 
 bool BasicMessage::DeliveryModeIsSet() const {
-  return AMQP_BASIC_DELIVERY_MODE_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_DELIVERY_MODE_FLAG);
+  return m_impl->delivery_mode.is_initialized();
 }
 
-void BasicMessage::DeliveryModeClear() {
-  m_impl->m_properties._flags &= ~AMQP_BASIC_DELIVERY_MODE_FLAG;
-}
+void BasicMessage::DeliveryModeClear() { m_impl->delivery_mode.reset(); }
 
 boost::uint8_t BasicMessage::Priority() const {
-  if (PriorityIsSet()) return m_impl->m_properties.priority;
-  return 0;
+  return m_impl->priority.value_or(0);
 }
+
 void BasicMessage::Priority(boost::uint8_t priority) {
-  m_impl->m_properties.priority = priority;
-  m_impl->m_properties._flags |= AMQP_BASIC_PRIORITY_FLAG;
+  m_impl->priority = priority;
 }
 
 bool BasicMessage::PriorityIsSet() const {
-  return AMQP_BASIC_PRIORITY_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_PRIORITY_FLAG);
+  return m_impl->priority.is_initialized();
 }
 
-void BasicMessage::PriorityClear() {
-  m_impl->m_properties._flags &= ~AMQP_BASIC_PRIORITY_FLAG;
+void BasicMessage::PriorityClear() { m_impl->priority.reset(); }
+
+const std::string& BasicMessage::CorrelationId() const {
+  if (CorrelationIdIsSet()) {
+    return m_impl->correlation_id.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::CorrelationId() const {
-  if (CorrelationIdIsSet())
-    return std::string((char *)m_impl->m_properties.correlation_id.bytes,
-                       m_impl->m_properties.correlation_id.len);
-  return std::string();
-}
-
-void BasicMessage::CorrelationId(const std::string &correlation_id) {
-  if (CorrelationIdIsSet())
-    amqp_bytes_free(m_impl->m_properties.correlation_id);
-  m_impl->m_properties.correlation_id =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(correlation_id.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_CORRELATION_ID_FLAG;
+void BasicMessage::CorrelationId(const std::string& correlation_id) {
+  m_impl->correlation_id = correlation_id;
 }
 
 bool BasicMessage::CorrelationIdIsSet() const {
-  return AMQP_BASIC_CORRELATION_ID_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_CORRELATION_ID_FLAG);
+  return m_impl->correlation_id.is_initialized();
 }
 
-void BasicMessage::CorrelationIdClear() {
-  if (CorrelationIdIsSet())
-    amqp_bytes_free(m_impl->m_properties.correlation_id);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_CORRELATION_ID_FLAG;
+void BasicMessage::CorrelationIdClear() { m_impl->correlation_id.reset(); }
+
+const std::string& BasicMessage::ReplyTo() const {
+  if (ReplyToIsSet()) {
+    return m_impl->reply_to.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::ReplyTo() const {
-  if (ReplyToIsSet())
-    return std::string((char *)m_impl->m_properties.reply_to.bytes,
-                       m_impl->m_properties.reply_to.len);
-  return std::string();
-}
-void BasicMessage::ReplyTo(const std::string &reply_to) {
-  if (ReplyToIsSet()) amqp_bytes_free(m_impl->m_properties.reply_to);
-  m_impl->m_properties.reply_to =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(reply_to.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_REPLY_TO_FLAG;
+void BasicMessage::ReplyTo(const std::string& reply_to) {
+  m_impl->reply_to = reply_to;
 }
 
 bool BasicMessage::ReplyToIsSet() const {
-  return AMQP_BASIC_REPLY_TO_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_REPLY_TO_FLAG);
+  return m_impl->reply_to.is_initialized();
 }
 
-void BasicMessage::ReplyToClear() {
-  if (ReplyToIsSet()) amqp_bytes_free(m_impl->m_properties.reply_to);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_REPLY_TO_FLAG;
+void BasicMessage::ReplyToClear() { m_impl->reply_to.reset(); }
+
+const std::string& BasicMessage::Expiration() const {
+  if (ExpirationIsSet()) {
+    return m_impl->expiration.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::Expiration() const {
-  if (ExpirationIsSet())
-    return std::string((char *)m_impl->m_properties.expiration.bytes,
-                       m_impl->m_properties.expiration.len);
-  return std::string();
-}
-void BasicMessage::Expiration(const std::string &expiration) {
-  if (ExpirationIsSet()) amqp_bytes_free(m_impl->m_properties.expiration);
-  m_impl->m_properties.expiration =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(expiration.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_EXPIRATION_FLAG;
+void BasicMessage::Expiration(const std::string& expiration) {
+  m_impl->expiration = expiration;
 }
 
 bool BasicMessage::ExpirationIsSet() const {
-  return AMQP_BASIC_EXPIRATION_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_EXPIRATION_FLAG);
+  return m_impl->expiration.is_initialized();
 }
 
-void BasicMessage::ExpirationClear() {
-  if (ExpirationIsSet()) amqp_bytes_free(m_impl->m_properties.expiration);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_EXPIRATION_FLAG;
+void BasicMessage::ExpirationClear() { m_impl->expiration.reset(); }
+
+const std::string& BasicMessage::MessageId() const {
+  if (MessageIdIsSet()) {
+    return m_impl->message_id.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::MessageId() const {
-  if (MessageIdIsSet())
-    return std::string((char *)m_impl->m_properties.message_id.bytes,
-                       m_impl->m_properties.message_id.len);
-  return std::string();
-}
-void BasicMessage::MessageId(const std::string &message_id) {
-  if (MessageIdIsSet()) amqp_bytes_free(m_impl->m_properties.message_id);
-  m_impl->m_properties.message_id =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(message_id.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_MESSAGE_ID_FLAG;
+void BasicMessage::MessageId(const std::string& message_id) {
+  m_impl->message_id = message_id;
 }
 
 bool BasicMessage::MessageIdIsSet() const {
-  return AMQP_BASIC_MESSAGE_ID_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_MESSAGE_ID_FLAG);
+  return m_impl->message_id.is_initialized();
 }
 
-void BasicMessage::MessageIdClear() {
-  if (MessageIdIsSet()) amqp_bytes_free(m_impl->m_properties.message_id);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_MESSAGE_ID_FLAG;
-}
+void BasicMessage::MessageIdClear() { m_impl->message_id.reset(); }
 
 boost::uint64_t BasicMessage::Timestamp() const {
-  if (TimestampIsSet()) return m_impl->m_properties.timestamp;
-  return 0;
+  return m_impl->timestamp.value_or(0);
 }
 void BasicMessage::Timestamp(boost::uint64_t timestamp) {
-  m_impl->m_properties.timestamp = timestamp;
-  m_impl->m_properties._flags |= AMQP_BASIC_TIMESTAMP_FLAG;
+  m_impl->timestamp = timestamp;
 }
 
 bool BasicMessage::TimestampIsSet() const {
-  return AMQP_BASIC_TIMESTAMP_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_TIMESTAMP_FLAG);
+  return m_impl->timestamp.is_initialized();
 }
 
-void BasicMessage::TimestampClear() {
-  m_impl->m_properties._flags &= ~AMQP_BASIC_TIMESTAMP_FLAG;
+void BasicMessage::TimestampClear() { m_impl->timestamp.reset(); }
+
+const std::string& BasicMessage::Type() const {
+  if (TypeIsSet()) {
+    return m_impl->type.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::Type() const {
-  if (TypeIsSet())
-    return std::string((char *)m_impl->m_properties.type.bytes,
-                       m_impl->m_properties.type.len);
-  return std::string();
-}
-void BasicMessage::Type(const std::string &type) {
-  if (TypeIsSet()) amqp_bytes_free(m_impl->m_properties.type);
-  m_impl->m_properties.type =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(type.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_TYPE_FLAG;
+void BasicMessage::Type(const std::string& type) { m_impl->type = type; }
+
+bool BasicMessage::TypeIsSet() const { return m_impl->type.is_initialized(); }
+
+void BasicMessage::TypeClear() { m_impl->type.reset(); }
+
+const std::string& BasicMessage::UserId() const {
+  if (UserIdIsSet()) {
+    return m_impl->user_id.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-bool BasicMessage::TypeIsSet() const {
-  return AMQP_BASIC_TYPE_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_TYPE_FLAG);
-}
-
-void BasicMessage::TypeClear() {
-  if (TypeIsSet()) amqp_bytes_free(m_impl->m_properties.type);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_TYPE_FLAG;
-}
-
-std::string BasicMessage::UserId() const {
-  if (UserIdIsSet())
-    return std::string((char *)m_impl->m_properties.user_id.bytes,
-                       m_impl->m_properties.user_id.len);
-  return std::string();
-}
-
-void BasicMessage::UserId(const std::string &user_id) {
-  if (UserIdIsSet()) amqp_bytes_free(m_impl->m_properties.user_id);
-  m_impl->m_properties.user_id =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(user_id.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_USER_ID_FLAG;
+void BasicMessage::UserId(const std::string& user_id) {
+  m_impl->user_id = user_id;
 }
 
 bool BasicMessage::UserIdIsSet() const {
-  return AMQP_BASIC_USER_ID_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_USER_ID_FLAG);
+  return m_impl->user_id.is_initialized();
 }
 
-void BasicMessage::UserIdClear() {
-  if (UserIdIsSet()) amqp_bytes_free(m_impl->m_properties.user_id);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_USER_ID_FLAG;
+void BasicMessage::UserIdClear() { m_impl->user_id.reset(); }
+
+const std::string& BasicMessage::AppId() const {
+  if (AppIdIsSet()) {
+    return m_impl->app_id.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::AppId() const {
-  if (AppIdIsSet())
-    return std::string((char *)m_impl->m_properties.app_id.bytes,
-                       m_impl->m_properties.app_id.len);
-  return std::string();
-}
-void BasicMessage::AppId(const std::string &app_id) {
-  if (AppIdIsSet()) amqp_bytes_free(m_impl->m_properties.app_id);
-  m_impl->m_properties.app_id =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(app_id.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_APP_ID_FLAG;
-}
+void BasicMessage::AppId(const std::string& app_id) { m_impl->app_id = app_id; }
 
 bool BasicMessage::AppIdIsSet() const {
-  return AMQP_BASIC_APP_ID_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_APP_ID_FLAG);
+  return m_impl->app_id.is_initialized();
 }
 
-void BasicMessage::AppIdClear() {
-  if (AppIdIsSet()) amqp_bytes_free(m_impl->m_properties.app_id);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_APP_ID_FLAG;
+void BasicMessage::AppIdClear() { m_impl->app_id.reset(); }
+
+const std::string& BasicMessage::ClusterId() const {
+  if (ClusterIdIsSet()) {
+    return m_impl->cluster_id.value();
+  }
+  static const std::string empty;
+  return empty;
 }
 
-std::string BasicMessage::ClusterId() const {
-  if (ClusterIdIsSet())
-    return std::string((char *)m_impl->m_properties.cluster_id.bytes,
-                       m_impl->m_properties.cluster_id.len);
-  return std::string();
-}
-void BasicMessage::ClusterId(const std::string &cluster_id) {
-  if (ClusterIdIsSet()) amqp_bytes_free(m_impl->m_properties.cluster_id);
-  m_impl->m_properties.cluster_id =
-      amqp_bytes_malloc_dup(amqp_cstring_bytes(cluster_id.c_str()));
-  m_impl->m_properties._flags |= AMQP_BASIC_CLUSTER_ID_FLAG;
+void BasicMessage::ClusterId(const std::string& cluster_id) {
+  m_impl->cluster_id = cluster_id;
 }
 
 bool BasicMessage::ClusterIdIsSet() const {
-  return AMQP_BASIC_CLUSTER_ID_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_CLUSTER_ID_FLAG);
+  return m_impl->cluster_id.is_initialized();
 }
 
-void BasicMessage::ClusterIdClear() {
-  if (ClusterIdIsSet()) amqp_bytes_free(m_impl->m_properties.cluster_id);
-  m_impl->m_properties._flags &= ~AMQP_BASIC_CLUSTER_ID_FLAG;
+void BasicMessage::ClusterIdClear() { m_impl->cluster_id.reset(); }
+
+Table& BasicMessage::HeaderTable() {
+  if (!HeaderTableIsSet()) {
+    m_impl->header_table = Table();
+  }
+  return m_impl->header_table.value();
 }
 
-Table BasicMessage::HeaderTable() const {
-  if (HeaderTableIsSet())
-    return Detail::TableValueImpl::CreateTable(m_impl->m_properties.headers);
-  return Table();
+const Table& BasicMessage::HeaderTable() const {
+  if (HeaderTableIsSet()) {
+    return m_impl->header_table.value();
+  }
+  static const Table empty;
+  return empty;
 }
 
-void BasicMessage::HeaderTable(const Table &header_table) {
-  m_impl->m_properties.headers = Detail::TableValueImpl::CreateAmqpTable(
-      header_table, m_impl->m_table_pool);
-  m_impl->m_properties._flags |= AMQP_BASIC_HEADERS_FLAG;
+void BasicMessage::HeaderTable(const Table& header_table) {
+  m_impl->header_table = header_table;
 }
 
 bool BasicMessage::HeaderTableIsSet() const {
-  return AMQP_BASIC_HEADERS_FLAG ==
-         (m_impl->m_properties._flags & AMQP_BASIC_HEADERS_FLAG);
+  return m_impl->header_table.is_initialized();
 }
 
-void BasicMessage::HeaderTableClear() {
-  if (HeaderTableIsSet()) {
-    m_impl->m_table_pool.reset();
-    m_impl->m_properties.headers.num_entries = 0;
-    m_impl->m_properties.headers.entries = NULL;
-  }
-  m_impl->m_properties._flags &= ~AMQP_BASIC_HEADERS_FLAG;
-}
+void BasicMessage::HeaderTableClear() { m_impl->header_table.reset(); }
 
 }  // namespace AmqpClient

--- a/src/SimpleAmqpClient/BasicMessage.h
+++ b/src/SimpleAmqpClient/BasicMessage.h
@@ -46,14 +46,7 @@
 /// @file SimpleAmqpClient/BasicMessage.h
 /// The AmqpClient::BasicMessage class is defined in this header file.
 
-struct amqp_bytes_t_;
-struct amqp_basic_properties_t_;
-
 namespace AmqpClient {
-
-namespace Detail {
-class BasicMessageImpl;
-}
 
 /**
  * An AMQP BasicMessage
@@ -64,7 +57,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   typedef boost::shared_ptr<BasicMessage> ptr_t;
 
   /// With durable queues, messages can be requested to persist or not
-  enum delivery_mode_t { dm_nonpersistent = 1, dm_persistent = 2 };
+  enum delivery_mode_t {
+    dm_notset = 0,
+    dm_nonpersistent = 1,
+    dm_persistent = 2
+  };
 
   /**
    * Create a new empty BasicMessage object
@@ -77,32 +74,14 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
    * @param body the message body.
    * @returns a new BasicMessage object
    */
-  static ptr_t Create(const std::string &body) {
+  static ptr_t Create(const std::string& body) {
     return boost::make_shared<BasicMessage>(body);
-  }
-
-  /**
-   * Create a new BasicMessage object with given body and properties
-   *
-   * @param body The message body. The message body is NOT copied.
-   * Passed in message body is deallocated when: body is set or message is
-   * destructed.
-   * @param properties The `amqp_basic_properties_t struct`. Note this makes a
-   * deep copy of the properties struct.
-   * @returns a new BasicMessage object
-   */
-  static ptr_t Create(amqp_bytes_t_ &body,
-                      amqp_basic_properties_t_ *properties) {
-    return boost::make_shared<BasicMessage>(body, properties);
   }
 
   /// Construct empty BasicMessage
   BasicMessage();
   /// Construct BasicMessage with given body
-  BasicMessage(const std::string &body);
-  /// Construct BasicMessage with given body and properties
-  BasicMessage(const amqp_bytes_t_ &body,
-               const amqp_basic_properties_t_ *properties);
+  BasicMessage(const std::string& body);
 
  public:
   /**
@@ -111,41 +90,24 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   virtual ~BasicMessage();
 
   /**
-   * INTERNAL INTERFACE: Gets the internal amqp_basic_properties_t struct
-   *
-   * Retrieves a reference to the internal structure used to keep track of
-   * the properties of the message. Changing members of this structure will
-   * modify the properties on the message.
-   * @returns the amqp_basic_properties_t* struct
-   */
-  const amqp_basic_properties_t_ *getAmqpProperties() const;
-
-  /**
-   * INTERNAL INTERFACE: Gets the amqp_bytes_t representation of the message
-   * body
-   *
-   * @returns the message body. Note this is owned by the message and will
-   * be freed when the BasicMessage is destructed
-   */
-  const amqp_bytes_t_ &getAmqpBody() const;
-
-  /**
    * Gets the message body as a std::string
    */
-  std::string Body() const;
+  const std::string& Body() const;
+  std::string& Body();
+
   /**
    * Sets the message body as a std::string
    */
-  void Body(const std::string &body);
+  void Body(const std::string& body);
 
   /**
    * Gets the content type property
    */
-  std::string ContentType() const;
+  const std::string& ContentType() const;
   /**
    * Sets the content type property
    */
-  void ContentType(const std::string &content_type);
+  void ContentType(const std::string& content_type);
   /**
    * Determines whether the content type property is set
    */
@@ -158,11 +120,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the content encoding property
    */
-  std::string ContentEncoding() const;
+  const std::string& ContentEncoding() const;
   /**
    * Sets the content encoding property
    */
-  void ContentEncoding(const std::string &content_encoding);
+  void ContentEncoding(const std::string& content_encoding);
   /**
    * Determines whether the content encoding property is set
    */
@@ -209,11 +171,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the correlation id property
    */
-  std::string CorrelationId() const;
+  const std::string& CorrelationId() const;
   /**
    * Sets the correlation id property
    */
-  void CorrelationId(const std::string &correlation_id);
+  void CorrelationId(const std::string& correlation_id);
   /**
    * Determines whether the correlation id property is set
    */
@@ -226,11 +188,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the reply to property
    */
-  std::string ReplyTo() const;
+  const std::string& ReplyTo() const;
   /**
    * Sets the reply to property
    */
-  void ReplyTo(const std::string &reply_to);
+  void ReplyTo(const std::string& reply_to);
   /**
    * Determines whether the reply to property is set
    */
@@ -243,11 +205,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the expiration property
    */
-  std::string Expiration() const;
+  const std::string& Expiration() const;
   /**
    * Sets the expiration property
    */
-  void Expiration(const std::string &expiration);
+  void Expiration(const std::string& expiration);
   /**
    * Determines whether the expiration property is set
    */
@@ -260,11 +222,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the message id property
    */
-  std::string MessageId() const;
+  const std::string& MessageId() const;
   /**
    * Sets the message id property
    */
-  void MessageId(const std::string &message_id);
+  void MessageId(const std::string& message_id);
   /**
    * Determines if the message id property is set
    */
@@ -294,11 +256,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the type property
    */
-  std::string Type() const;
+  const std::string& Type() const;
   /**
    * Sets the type property
    */
-  void Type(const std::string &type);
+  void Type(const std::string& type);
   /**
    * Determines whether the type property is set
    */
@@ -311,11 +273,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the user id property
    */
-  std::string UserId() const;
+  const std::string& UserId() const;
   /**
    * Sets the user id property
    */
-  void UserId(const std::string &user_id);
+  void UserId(const std::string& user_id);
   /**
    * Determines whether the user id property is set
    */
@@ -328,11 +290,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the app id property
    */
-  std::string AppId() const;
+  const std::string& AppId() const;
   /**
    * Sets the app id property
    */
-  void AppId(const std::string &app_id);
+  void AppId(const std::string& app_id);
   /**
    * Determines whether the app id property is set
    */
@@ -345,11 +307,11 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the cluster id property
    */
-  std::string ClusterId() const;
+  const std::string& ClusterId() const;
   /**
    * Sets the custer id property
    */
-  void ClusterId(const std::string &cluster_id);
+  void ClusterId(const std::string& cluster_id);
   /**
    * Determines if the cluster id property is set
    */
@@ -362,11 +324,12 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   /**
    * Gets the header table property
    */
-  Table HeaderTable() const;
+  Table& HeaderTable();
+  const Table& HeaderTable() const;
   /**
    * Sets the header table property
    */
-  void HeaderTable(const Table &header_table);
+  void HeaderTable(const Table& header_table);
   /**
    * Is there a header table associated with the message
    */
@@ -377,8 +340,9 @@ class SIMPLEAMQPCLIENT_EXPORT BasicMessage : boost::noncopyable {
   void HeaderTableClear();
 
  protected:
+  struct Impl;
   /// PIMPL idiom
-  boost::scoped_ptr<Detail::BasicMessageImpl> m_impl;
+  boost::scoped_ptr<Impl> m_impl;
 };
 
 }  // namespace AmqpClient

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -66,7 +66,7 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
   typedef boost::shared_ptr<Channel> ptr_t;
 
   static const std::string
-      EXCHANGE_TYPE_DIRECT;                      ///< `"direct"` string constant
+      EXCHANGE_TYPE_DIRECT;  ///< `"direct"` string constant
   static const std::string
       EXCHANGE_TYPE_FANOUT;                      ///< `"fanout"` string constant
   static const std::string EXCHANGE_TYPE_TOPIC;  ///< `"topic"` string constant

--- a/testing/test_message.cpp
+++ b/testing/test_message.cpp
@@ -109,21 +109,11 @@ TEST(basic_message, embedded_nulls) {
   BasicMessage::ptr_t message = BasicMessage::Create(body);
   EXPECT_EQ(body, message->Body());
 
-  amqp_bytes_t amqp_body = message->getAmqpBody();
-  EXPECT_EQ(body.length(), amqp_body.len);
-  EXPECT_TRUE(std::equal(message_data.begin(), message_data.end(),
-                         reinterpret_cast<char *>(amqp_body.bytes)));
-
   const boost::array<char, 7> message_data2 = {
       {'1', '2', '3', 0, 'a', 'b', 'c'}};
   const std::string body2(message_data2.data(), message_data2.size());
   message->Body(body2);
   EXPECT_EQ(body2, message->Body());
-
-  amqp_bytes_t amqp_body2 = message->getAmqpBody();
-  EXPECT_EQ(body2.length(), amqp_body2.len);
-  EXPECT_TRUE(std::equal(message_data2.begin(), message_data2.end(),
-                         reinterpret_cast<char *>(amqp_body2.bytes)));
 }
 
 TEST_F(connected_test, replaced_received_body) {


### PR DESCRIPTION
This makes BasicMessage more value-type like, and removes forward
references to rabbitmq-c structs from the public API.

As a side-effect most accessor functions now return const-ref, which is
likely more efficient in most cases, though may cause an unexpected
behavior changes depending on how the API is used.