### PR TITLE
lib: add support for table timestamp values & remove broken support for uint64 values.

### DIFF
--- a/src/SimpleAmqpClient/Table.h
+++ b/src/SimpleAmqpClient/Table.h
@@ -28,8 +28,10 @@
  * ***** END LICENSE BLOCK *****
  */
 
+#include <boost/chrono.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <ctime>
 #include <map>
 #include <string>
 #include <vector>
@@ -82,21 +84,21 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
 
   /** Types enumeration */
   enum ValueType {
-    VT_void = 0,     ///< void type
-    VT_bool = 1,     ///< boolean type
-    VT_int8 = 2,     ///< 1-byte/char signed type
-    VT_int16 = 3,    ///< 2-byte/short signed type
-    VT_int32 = 4,    ///< 4-byte/int signed type
-    VT_int64 = 5,    ///< 8-byte/long long int signed type
-    VT_float = 6,    ///< single-precision floating point type
-    VT_double = 7,   ///< double-precision floating point type
-    VT_string = 8,   ///< string type
-    VT_array = 9,    ///< array of TableValues type
-    VT_table = 10,   ///< a table type
-    VT_uint8 = 11,   ///< 1-byte/char unsigned type
-    VT_uint16 = 12,  ///< 2-byte/short unsigned type
-    VT_uint32 = 13,  ///< 4-byte/int unsigned type
-    VT_uint64 = 14   ///< 8-byte/long long int unsigned type
+    VT_void = 0,        ///< void type
+    VT_bool = 1,        ///< boolean type
+    VT_int8 = 2,        ///< 1-byte/char signed type
+    VT_int16 = 3,       ///< 2-byte/short signed type
+    VT_int32 = 4,       ///< 4-byte/int signed type
+    VT_int64 = 5,       ///< 8-byte/long long int signed type
+    VT_float = 6,       ///< single-precision floating point type
+    VT_double = 7,      ///< double-precision floating point type
+    VT_string = 8,      ///< string type
+    VT_array = 9,       ///< array of TableValues type
+    VT_table = 10,      ///< a table type
+    VT_uint8 = 11,      ///< 1-byte/char unsigned type
+    VT_uint16 = 12,     ///< 2-byte/short unsigned type
+    VT_uint32 = 13,     ///< 4-byte/int unsigned type
+    VT_timestamp = 14,  ///< std::time_t type
   };
 
   /**
@@ -155,12 +157,24 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
    */
   TableValue(boost::int32_t value);
 
+ private:
   /**
-   * Construct a 8-byte unsigned integer value
+   * Private
+   *
+   * RabbitMQ does not support unsigned 64-bit values in tables,
+   * however, timestamps are used for this.
+   */
+  TableValue(boost::uint64_t value);
+
+ public:
+  /**
+   * Construct an AMQP timestamp TableValue
+   *
+   * This seconds since epoch.
    *
    * @param [in] value the value
    */
-  TableValue(boost::uint64_t value);
+  static TableValue Timestamp(std::time_t value);
 
   /**
    * Construct a 8-byte signed integer value
@@ -298,6 +312,13 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   boost::uint64_t GetUint64() const;
 
   /**
+   * Get the timestamp value
+   *
+   * @returns the value if its a VT_timestamp type, 0 otherwise
+   */
+  std::time_t GetTimestamp() const;
+
+  /**
    * Get the int64 value
    *
    * @returns the value if its a VT_int64 type, 0 otherwise
@@ -312,8 +333,7 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
    * of uint64_t is possible, please use GetUint64()
    *
    * @returns an integer number if the ValueType is VT_uint8, VT_int8,
-   * VT_uint16, VT_int16, VT_uint32, VT_int32, VT_uint64
-   * or VT_int64 type, 0 otherwise
+   * VT_uint16, VT_int16, VT_uint32, VT_int32,or VT_int64 type, 0 otherwise.
    */
   boost::int64_t GetInteger() const;
 
@@ -414,14 +434,14 @@ class SIMPLEAMQPCLIENT_EXPORT TableValue {
   void Set(boost::int32_t value);
 
   /**
-   * Set teh value as a uint64_t
+   * Set the value as a timestamp.
    *
    * @param [in] value the value
    */
-  void Set(boost::uint64_t value);
+  void SetTimestamp(std::time_t value);
 
   /**
-   * Set teh value as a int64_t
+   * Set the value as a int64_t
    *
    * @param [in] value the value
    */

--- a/src/SimpleAmqpClient/TableImpl.h
+++ b/src/SimpleAmqpClient/TableImpl.h
@@ -33,6 +33,7 @@
 #include <boost/cstdint.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/variant/variant.hpp>
+#include <ctime>
 #include <string>
 #include <vector>
 

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
+#include <ctime>
 #include <iterator>
 #include <limits>
 #include <stdexcept>
@@ -64,6 +65,10 @@ TableValue::TableValue(boost::int32_t value)
 
 TableValue::TableValue(boost::uint64_t value)
     : m_impl(new Detail::TableValueImpl(value)) {}
+
+TableValue TableValue::Timestamp(std::time_t ts) {
+  return TableValue(static_cast<boost::uint64_t>(ts));
+}
 
 TableValue::TableValue(boost::int64_t value)
     : m_impl(new Detail::TableValueImpl(value)) {}
@@ -158,8 +163,8 @@ boost::int32_t TableValue::GetInt32() const {
   return boost::get<boost::int32_t>(m_impl->m_value);
 }
 
-boost::uint64_t TableValue::GetUint64() const {
-  return boost::get<boost::uint64_t>(m_impl->m_value);
+std::time_t TableValue::GetTimestamp() const {
+  return static_cast<std::time_t>(boost::get<boost::uint64_t>(m_impl->m_value));
 }
 
 boost::int64_t TableValue::GetInt64() const {
@@ -180,13 +185,6 @@ boost::int64_t TableValue::GetInteger() const {
       return GetUint32();
     case VT_int32:
       return GetInt32();
-    case VT_uint64: {
-      const boost::uint64_t value = GetUint64();
-      if (value > static_cast<boost::uint64_t>(
-                      std::numeric_limits<boost::int64_t>::max()))
-        throw std::overflow_error("Result of GetUint64() is out of range.");
-      return value;
-    }
     case VT_int64:
       return GetInt64();
     default:
@@ -241,7 +239,9 @@ void TableValue::Set(boost::uint32_t value) { m_impl->m_value = value; }
 
 void TableValue::Set(boost::int32_t value) { m_impl->m_value = value; }
 
-void TableValue::Set(boost::uint64_t value) { m_impl->m_value = value; }
+void TableValue::SetTimestamp(std::time_t value) {
+  m_impl->m_value = static_cast<boost::uint64_t>(value);
+}
 
 void TableValue::Set(boost::int64_t value) { m_impl->m_value = value; }
 

--- a/src/TableImpl.cpp
+++ b/src/TableImpl.cpp
@@ -114,7 +114,7 @@ amqp_field_value_t TableValueImpl::generate_field_value::operator()(
 amqp_field_value_t TableValueImpl::generate_field_value::operator()(
     const boost::uint64_t value) const {
   amqp_field_value_t v;
-  v.kind = AMQP_FIELD_KIND_U64;
+  v.kind = AMQP_FIELD_KIND_TIMESTAMP;
   v.value.u64 = value;
   return v;
 }
@@ -259,7 +259,6 @@ TableValue TableValueImpl::CreateTableValue(const amqp_field_value_t &entry) {
       return TableValue(entry.value.u32);
     case AMQP_FIELD_KIND_I32:
       return TableValue(entry.value.i32);
-    case AMQP_FIELD_KIND_U64:
     case AMQP_FIELD_KIND_TIMESTAMP:
       return TableValue(entry.value.u64);
     case AMQP_FIELD_KIND_I64:
@@ -285,6 +284,8 @@ TableValue TableValueImpl::CreateTableValue(const amqp_field_value_t &entry) {
     case AMQP_FIELD_KIND_TABLE:
       return TableValue(CreateTable(entry.value.table));
     case AMQP_FIELD_KIND_DECIMAL:
+    // uint64_t is unsupported by RabbitMQ.
+    case AMQP_FIELD_KIND_U64:
     default:
       return TableValue();
   }

--- a/testing/test_table.cpp
+++ b/testing/test_table.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
+#include <ctime>
 
 #include "connected_test.h"
 
@@ -45,7 +46,7 @@ TEST(table_value, void_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -65,7 +66,7 @@ TEST(table_value, void_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -90,7 +91,7 @@ TEST(table_value, bool_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -110,7 +111,7 @@ TEST(table_value, bool_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -136,7 +137,7 @@ TEST(table_value, uint8_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -156,7 +157,7 @@ TEST(table_value, uint8_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -181,7 +182,7 @@ TEST(table_value, int8_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -201,7 +202,7 @@ TEST(table_value, int8_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -226,7 +227,7 @@ TEST(table_value, uint16_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -246,7 +247,7 @@ TEST(table_value, uint16_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -271,7 +272,7 @@ TEST(table_value, int16_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -291,7 +292,7 @@ TEST(table_value, int16_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -316,7 +317,7 @@ TEST(table_value, uint32_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -336,7 +337,7 @@ TEST(table_value, uint32_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -361,7 +362,7 @@ TEST(table_value, int32_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -381,7 +382,7 @@ TEST(table_value, int32_value) {
   EXPECT_THROW(value.GetUint16(), boost::bad_get);
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -391,14 +392,13 @@ TEST(table_value, int32_value) {
   EXPECT_THROW(value.GetTable(), boost::bad_get);
 }
 
-TEST(table_value, uint64_value) {
-  boost::uint64_t v1 = 1;
-  boost::uint64_t v2 = 2;
+TEST(table_value, timestamp_value) {
+  std::time_t v1 = 1;
+  std::time_t v2 = 2;
 
-  TableValue value(v1);
-  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
-  EXPECT_EQ(v1, value.GetUint64());
-  EXPECT_EQ(v1, value.GetInteger());
+  TableValue value = TableValue::Timestamp(v1);
+  EXPECT_EQ(TableValue::VT_timestamp, value.GetType());
+  EXPECT_EQ(v1, value.GetTimestamp());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
   EXPECT_THROW(value.GetUint8(), boost::bad_get);
@@ -408,6 +408,7 @@ TEST(table_value, uint64_value) {
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
+  EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -415,10 +416,9 @@ TEST(table_value, uint64_value) {
   EXPECT_THROW(value.GetArray(), boost::bad_get);
   EXPECT_THROW(value.GetTable(), boost::bad_get);
 
-  value.Set(v2);
-  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
-  EXPECT_EQ(v2, value.GetUint64());
-  EXPECT_EQ(v2, value.GetInteger());
+  value.SetTimestamp(v2);
+  EXPECT_EQ(TableValue::VT_timestamp, value.GetType());
+  EXPECT_EQ(v2, value.GetTimestamp());
 
   EXPECT_THROW(value.GetBool(), boost::bad_get);
   EXPECT_THROW(value.GetUint8(), boost::bad_get);
@@ -428,53 +428,7 @@ TEST(table_value, uint64_value) {
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
-  EXPECT_THROW(value.GetFloat(), boost::bad_get);
-  EXPECT_THROW(value.GetDouble(), boost::bad_get);
-  EXPECT_THROW(value.GetReal(), boost::bad_get);
-  EXPECT_THROW(value.GetString(), boost::bad_get);
-  EXPECT_THROW(value.GetArray(), boost::bad_get);
-  EXPECT_THROW(value.GetTable(), boost::bad_get);
-}
-
-TEST(table_value, uint64_value_larger_than_int64_max) {
-  const boost::uint64_t maxInt64 =
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
-  boost::uint64_t v1 = maxInt64 + 1;
-  boost::uint64_t v2 = maxInt64 + 2;
-
-  TableValue value(v1);
-  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
-  EXPECT_EQ(v1, value.GetUint64());
-
-  EXPECT_THROW(value.GetBool(), boost::bad_get);
-  EXPECT_THROW(value.GetUint8(), boost::bad_get);
-  EXPECT_THROW(value.GetInt8(), boost::bad_get);
-  EXPECT_THROW(value.GetUint16(), boost::bad_get);
-  EXPECT_THROW(value.GetInt16(), boost::bad_get);
-  EXPECT_THROW(value.GetUint32(), boost::bad_get);
-  EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetInt64(), boost::bad_get);
-  EXPECT_THROW(value.GetInteger(), std::overflow_error);
-  EXPECT_THROW(value.GetFloat(), boost::bad_get);
-  EXPECT_THROW(value.GetDouble(), boost::bad_get);
-  EXPECT_THROW(value.GetReal(), boost::bad_get);
-  EXPECT_THROW(value.GetString(), boost::bad_get);
-  EXPECT_THROW(value.GetArray(), boost::bad_get);
-  EXPECT_THROW(value.GetTable(), boost::bad_get);
-
-  value.Set(v2);
-  EXPECT_EQ(TableValue::VT_uint64, value.GetType());
-  EXPECT_EQ(v2, value.GetUint64());
-
-  EXPECT_THROW(value.GetBool(), boost::bad_get);
-  EXPECT_THROW(value.GetUint8(), boost::bad_get);
-  EXPECT_THROW(value.GetInt8(), boost::bad_get);
-  EXPECT_THROW(value.GetUint16(), boost::bad_get);
-  EXPECT_THROW(value.GetInt16(), boost::bad_get);
-  EXPECT_THROW(value.GetUint32(), boost::bad_get);
-  EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetInt64(), boost::bad_get);
-  EXPECT_THROW(value.GetInteger(), std::overflow_error);
+  EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -499,7 +453,7 @@ TEST(table_value, int64_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -519,7 +473,7 @@ TEST(table_value, int64_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
   EXPECT_THROW(value.GetReal(), boost::bad_get);
@@ -544,7 +498,7 @@ TEST(table_value, float_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -564,7 +518,7 @@ TEST(table_value, float_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetDouble(), boost::bad_get);
@@ -589,7 +543,7 @@ TEST(table_value, double_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -609,7 +563,7 @@ TEST(table_value, double_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -633,7 +587,7 @@ TEST(table_value, string_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -653,7 +607,7 @@ TEST(table_value, string_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -683,7 +637,7 @@ TEST(table_value, array_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -705,7 +659,7 @@ TEST(table_value, array_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -735,7 +689,7 @@ TEST(table_value, table_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -757,7 +711,7 @@ TEST(table_value, table_value) {
   EXPECT_THROW(value.GetInt16(), boost::bad_get);
   EXPECT_THROW(value.GetUint32(), boost::bad_get);
   EXPECT_THROW(value.GetInt32(), boost::bad_get);
-  EXPECT_THROW(value.GetUint64(), boost::bad_get);
+  EXPECT_THROW(value.GetTimestamp(), boost::bad_get);
   EXPECT_THROW(value.GetInt64(), boost::bad_get);
   EXPECT_THROW(value.GetInteger(), boost::bad_get);
   EXPECT_THROW(value.GetFloat(), boost::bad_get);
@@ -839,7 +793,7 @@ TEST(table, convert_to_rabbitmq) {
   table_in.insert(TableEntry("int16_key", int16_t(16)));
   table_in.insert(TableEntry("uint32_key", uint32_t(32)));
   table_in.insert(TableEntry("int32_key", int32_t(32)));
-  table_in.insert(TableEntry("uint64_key", uint64_t(64)));
+  table_in.insert(TableEntry("timestamp_key", TableValue::Timestamp(64)));
   table_in.insert(TableEntry("int64_key", int64_t(64)));
   table_in.insert(TableEntry("float_key", float(1.5)));
   table_in.insert(TableEntry("double_key", double(2.25)));
@@ -887,7 +841,7 @@ TEST_F(connected_test, basic_message_header_roundtrip) {
   table_in.insert(TableEntry("int16_key", int16_t(16)));
   table_in.insert(TableEntry("uint32_key", uint32_t(32)));
   table_in.insert(TableEntry("int32_key", int32_t(32)));
-  table_in.insert(TableEntry("uint64_key", uint64_t(64)));
+  table_in.insert(TableEntry("timestamp_key", TableValue::Timestamp(64)));
   table_in.insert(TableEntry("int64_key", int64_t(64)));
   table_in.insert(TableEntry("float_key", float(1.5)));
   table_in.insert(TableEntry("double_key", double(2.25)));


### PR DESCRIPTION
uint64_t table values aren't supported by RabbitMQ: they cause
connection errors in older versions of RabbitMQ, and newer brokers
silently convert them to int64_t.

Timestamps are still represented using uin64_t, so this adds an API that
supports setting Timestamps. The interface is a bit different as
std::time_t is a typedef of another integral type and will conflict with
other overloads in existing overload sets.