### PR TITLE
build: restore GNUInstallDirs include (#265, #266)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ if (BUILD_API_DOCS)
     )
 endif ()
 
+include(GNUInstallDirs)
+
 install(TARGETS SimpleAmqpClient
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
Include was mistakenly removed due to bad merge, this restores that.

Fixed: #265
Fixed: #266