### PR TITLE
lib: switch to StringToBytes from amqp_cstring_bytes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ set(SAC_LIB_SRCS
     src/SimpleAmqpClient/AmqpException.h
     src/AmqpException.cpp
 
+    src/SimpleAmqpClient/Bytes.h
+
     src/SimpleAmqpClient/Channel.h
     src/Channel.cpp
 

--- a/src/SimpleAmqpClient/Bytes.h
+++ b/src/SimpleAmqpClient/Bytes.h
@@ -1,0 +1,17 @@
+#ifndef SIMPLEAMQPCLIENT_BYTES_H
+#define SIMPLEAMQPCLIENT_BYTES_H
+
+#include <amqp.h>
+#include <string>
+
+namespace AmqpClient {
+
+amqp_bytes_t StringToBytes(const std::string& str) {
+  amqp_bytes_t ret;
+  ret.bytes = reinterpret_cast<void*>(const_cast<char*>(str.data()));
+  ret.len = str.length();
+  return ret;
+}
+
+}  // namespace AmqpClient
+#endif  // SIMPLEAMQPCLIENT_BYTES_H


### PR DESCRIPTION
The latter is somewhat more efficient as it doesn't need to call strlen,
thus its O(1) instead of O(N) on string size.