### PR TITLE
Fix setting of flags in CreateAmqpProperties()

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -97,36 +97,36 @@ amqp_basic_properties_t CreateAmqpProperties(const BasicMessage &mes,
   }
   if (mes.ExpirationIsSet()) {
     ret.expiration = StringToBytes(mes.Expiration());
-    ret._flags = AMQP_BASIC_EXPIRATION_FLAG;
+    ret._flags |= AMQP_BASIC_EXPIRATION_FLAG;
   }
   if (mes.MessageIdIsSet()) {
     ret.message_id = StringToBytes(mes.MessageId());
-    ret._flags = AMQP_BASIC_MESSAGE_ID_FLAG;
+    ret._flags |= AMQP_BASIC_MESSAGE_ID_FLAG;
   }
   if (mes.TimestampIsSet()) {
     ret.timestamp = mes.Timestamp();
-    ret._flags = AMQP_BASIC_TIMESTAMP_FLAG;
+    ret._flags |= AMQP_BASIC_TIMESTAMP_FLAG;
   }
   if (mes.TypeIsSet()) {
     ret.type = StringToBytes(mes.Type());
-    ret._flags = AMQP_BASIC_TYPE_FLAG;
+    ret._flags |= AMQP_BASIC_TYPE_FLAG;
   }
   if (mes.UserIdIsSet()) {
     ret.user_id = StringToBytes(mes.UserId());
-    ret._flags = AMQP_BASIC_USER_ID_FLAG;
+    ret._flags |= AMQP_BASIC_USER_ID_FLAG;
   }
   if (mes.AppIdIsSet()) {
     ret.app_id = StringToBytes(mes.AppId());
-    ret._flags = AMQP_BASIC_APP_ID_FLAG;
+    ret._flags |= AMQP_BASIC_APP_ID_FLAG;
   }
   if (mes.ClusterIdIsSet()) {
     ret.cluster_id = StringToBytes(mes.ClusterId());
-    ret._flags = AMQP_BASIC_CLUSTER_ID_FLAG;
+    ret._flags |= AMQP_BASIC_CLUSTER_ID_FLAG;
   }
   if (mes.HeaderTableIsSet()) {
     ret.headers =
         Detail::TableValueImpl::CreateAmqpTable(mes.HeaderTable(), pool);
-    ret._flags = AMQP_BASIC_HEADERS_FLAG;
+    ret._flags |= AMQP_BASIC_HEADERS_FLAG;
   }
   return ret;
 }


### PR DESCRIPTION
We cannot just replace the entire `ret._flags` variable when setting certain message properties. We need to OR the variable with the corresponding flag. Otherwise, setting e.g. message expiration resets all the previously set flags, such as for priority or delivery mode. Many flags are ORed correctly (e.g. priority or delivery mode), but some are not. This PR fixes that.

The bug that this PR fixes was introduced in commit 938b102f8fc85e5113b3e55700b8af9b71d9f01d.