### PR TITLE
Cmake config generate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,8 +196,8 @@ include(GNUInstallDirs)
 
 include(CMakePackageConfigHelpers)
 set(SAC_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/SimpleAmqpClient)
-set(project_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClient-config.cmake")
-set(version_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClient-config-version.cmake")
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClientConfig.cmake")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClientConfig-version.cmake")
 set(targets_export_name SimpleAmqpClient-targets)
 list(APPEND INSTALL_TARGETS SimpleAmqpClient)
 
@@ -208,7 +208,7 @@ write_basic_package_version_file(
 	)
 
 configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SimpleAmqpClient-config.cmake.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SimpleAmqpClientConfig.cmake.in"
     "${project_config}"
     INSTALL_DESTINATION "${SAC_CMAKE_DIR}"
 	)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,34 @@ endif ()
 
 include(GNUInstallDirs)
 
+include(CMakePackageConfigHelpers)
+set(SAC_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/SimpleAmqpClient)
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClient-config.cmake")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/SimpleAmqpClient-config-version.cmake")
+set(targets_export_name SimpleAmqpClient-targets)
+list(APPEND INSTALL_TARGETS SimpleAmqpClient)
+
+write_basic_package_version_file(
+    "${version_config}"
+    VERSION ${SAC_VERSION}
+    COMPATIBILITY AnyNewerVersion
+	)
+￼
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SimpleAmqpClient-config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${SAC_CMAKE_DIR}"
+	)
+
+install(FILES ${project_config} ${version_config}
+    DESTINATION ${SAC_CMAKE_DIR}
+    )
+
+install(EXPORT ${targets_export_name}
+    DESTINATION ${SAC_CMAKE_DIR}
+    NAMESPACE SimpleAmqpClient::
+    )
+
 install(TARGETS SimpleAmqpClient
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,12 +206,18 @@ write_basic_package_version_file(
     VERSION ${SAC_VERSION}
     COMPATIBILITY AnyNewerVersion
 	)
-￼
+
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SimpleAmqpClient-config.cmake.in"
     "${project_config}"
     INSTALL_DESTINATION "${SAC_CMAKE_DIR}"
 	)
+
+install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
 
 install(FILES ${project_config} ${version_config}
     DESTINATION ${SAC_CMAKE_DIR}
@@ -220,12 +226,6 @@ install(FILES ${project_config} ${version_config}
 install(EXPORT ${targets_export_name}
     DESTINATION ${SAC_CMAKE_DIR}
     NAMESPACE SimpleAmqpClient::
-    )
-
-install(TARGETS SimpleAmqpClient
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 
 install(FILES

--- a/cmake/SimpleAmqpClient-config.cmake.in
+++ b/cmake/SimpleAmqpClient-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+￼	
+include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)

--- a/cmake/SimpleAmqpClientConfig.cmake.in
+++ b/cmake/SimpleAmqpClientConfig.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
-￼	
+
 include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)


### PR DESCRIPTION
Adds generation of CMake config.
Allows to use `find_package(SimpleAmqpClient)` out of the box

#288 