### PR TITLE
Optionally set ca cert path

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -421,11 +421,14 @@ Channel::ChannelImpl *Channel::OpenSecureChannel(
 #endif
 
   try {
-    int status =
-        amqp_ssl_socket_set_cacert(socket, tls_params.ca_cert_path.c_str());
-    if (status) {
-      throw AmqpLibraryException::CreateException(
-          status, "Error setting CA certificate for socket");
+    int status;
+    if (tls_params.ca_cert_path != "") {
+      status =
+          amqp_ssl_socket_set_cacert(socket, tls_params.ca_cert_path.c_str());
+      if (status) {
+        throw AmqpLibraryException::CreateException(
+            status, "Error setting CA certificate for socket");
+      }
     }
 
     if (tls_params.client_key_path != "" && tls_params.client_cert_path != "") {


### PR DESCRIPTION
Hi @alanxz. Thanks for all the good work.

This PR should resolve:
- https://github.com/alanxz/SimpleAmqpClient/issues/178
- https://github.com/alanxz/SimpleAmqpClient/issues/294
- https://github.com/alanxz/SimpleAmqpClient/issues/295

There are all requiring the same thing - to optionally skip the call to the c library `amqp_ssl_socket_set_cacert`

I've tested it locally with no problems.

Kind regards,
Paul