### PR TITLE
Explicitly set basic.qos.global fixes #276

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -939,10 +939,28 @@ std::string Channel::BasicConsume(const std::string &queue,
   return BasicConsume(queue, consumer_tag, no_local, no_ack, exclusive,
                       message_prefetch_count, Table());
 }
+
+std::string Channel::BasicConsume(const std::string& queue,
+                                  const std::string& consumer_tag,
+                                  bool no_local, bool no_ack, bool exclusive,
+                                  boost::uint16_t message_prefetch_count, bool globalQos) {
+  return BasicConsume(queue, consumer_tag, no_local, no_ack, exclusive,
+                      message_prefetch_count, globalQos, Table());
+}
+
 std::string Channel::BasicConsume(const std::string &queue,
                                   const std::string &consumer_tag,
                                   bool no_local, bool no_ack, bool exclusive,
                                   boost::uint16_t message_prefetch_count,
+                                  const Table &arguments) {
+  return BasicConsume(queue, consumer_tag, no_local, no_ack, exclusive,
+                      message_prefetch_count, m_impl->BrokerHasNewQosBehavior(), Table());
+}
+
+std::string Channel::BasicConsume(const std::string &queue,
+                                  const std::string &consumer_tag,
+                                  bool no_local, bool no_ack, bool exclusive,
+                                  boost::uint16_t message_prefetch_count, bool globalQos,
                                   const Table &arguments) {
   m_impl->CheckIsConnected();
   amqp_channel_t channel = m_impl->GetChannel();
@@ -954,7 +972,7 @@ std::string Channel::BasicConsume(const std::string &queue,
   amqp_basic_qos_t qos = {};
   qos.prefetch_size = 0;
   qos.prefetch_count = message_prefetch_count;
-  qos.global = m_impl->BrokerHasNewQosBehavior();
+  qos.global = globalQos;
 
   m_impl->DoRpcOnChannel(channel, AMQP_BASIC_QOS_METHOD, &qos, QOS_OK);
   m_impl->MaybeReleaseBuffersOnChannel(channel);
@@ -988,8 +1006,13 @@ std::string Channel::BasicConsume(const std::string &queue,
   return tag;
 }
 
-void Channel::BasicQos(const std::string &consumer_tag,
+void Channel::BasicQos(const std::string& consumer_tag,
                        boost::uint16_t message_prefetch_count) {
+  BasicQos(consumer_tag, message_prefetch_count, m_impl->BrokerHasNewQosBehavior());
+}
+
+void Channel::BasicQos(const std::string &consumer_tag,
+                       boost::uint16_t message_prefetch_count, bool globalQos) {
   m_impl->CheckIsConnected();
   amqp_channel_t channel = m_impl->GetConsumerChannel(consumer_tag);
 
@@ -998,7 +1021,7 @@ void Channel::BasicQos(const std::string &consumer_tag,
   amqp_basic_qos_t qos = {};
   qos.prefetch_size = 0;
   qos.prefetch_count = message_prefetch_count;
-  qos.global = m_impl->BrokerHasNewQosBehavior();
+  qos.global = globalQos;
 
   m_impl->DoRpcOnChannel(channel, AMQP_BASIC_QOS_METHOD, &qos, QOS_OK);
   m_impl->MaybeReleaseBuffersOnChannel(channel);

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -794,6 +794,36 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
    * deliver. Setting this to more than 1 will allow the broker to deliver
    * messages while a current message is being processed. A value of
    * 0 means no limit. This option is ignored if `no_ack = true`.
+   * @param globalQos Sets basic.qos.global explicitly.
+   * @returns the consumer tag
+   */
+  std::string BasicConsume(const std::string &queue,
+                           const std::string &consumer_tag = "",
+                           bool no_local = true, bool no_ack = true,
+                           bool exclusive = true,
+                           boost::uint16_t message_prefetch_count = 1,
+                           bool globalQos = false);
+
+  /**
+   * Starts consuming Basic messages on a queue
+   *
+   * Subscribes as a consumer to a queue, so all future messages on a queue
+   * will be Basic.Delivered
+   * @note Due to a limitation to how things are done, it is only possible to
+   * reliably have **a single consumer per channel**; calling this
+   * more than once per channel may result in undefined results.
+   * @param queue The name of the queue to subscribe to.
+   * @param consumer_tag The name of the consumer. This is used to do
+   * operations with a consumer.
+   * @param no_local Defaults to true
+   * @param no_ack If `true`, ack'ing the message is automatically done when the
+   * message is delivered. Defaults to `true` (message does not have to be
+   * ack'ed).
+   * @param exclusive Means only this consumer can access the queue.
+   * @param message_prefetch_count Number of unacked messages the broker will
+   * deliver. Setting this to more than 1 will allow the broker to deliver
+   * messages while a current message is being processed. A value of
+   * 0 means no limit. This option is ignored if `no_ack = true`.
    * @param arguments A table of additional arguments when creating the consumer
    * @returns the consumer tag
    */
@@ -801,6 +831,38 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
                            const std::string &consumer_tag, bool no_local,
                            bool no_ack, bool exclusive,
                            boost::uint16_t message_prefetch_count,
+                           const Table &arguments);
+
+  /**
+    * Starts consuming Basic messages on a queue
+    *
+    * Subscribes as a consumer to a queue, so all future messages on a queue
+    * will be Basic.Delivered
+    * @note Due to a limitation to how things are done, it is only possible to
+    * reliably have **a single consumer per channel**; calling this
+    * more than once per channel may result in undefined results.
+    * @param queue The name of the queue to subscribe to.
+    * @param consumer_tag The name of the consumer. This is used to do
+    * operations with a consumer.
+    * @param no_local Defaults to true
+    * @param no_ack If `true`, ack'ing the message is automatically done when
+    * the message is delivered. Defaults to `true` (message does not have to be
+    * ack'ed).
+    * @param exclusive Means only this consumer can access the queue.
+    * @param message_prefetch_count Number of unacked messages the broker will
+    * deliver. Setting this to more than 1 will allow the broker to deliver
+    * messages while a current message is being processed. A value of
+    * 0 means no limit. This option is ignored if `no_ack = true`.
+    * @param globalQos Sets basic.qos.global explicitly.
+    * @param arguments A table of additional arguments when creating the
+    * consumer
+    * @returns the consumer tag
+    */
+  std::string BasicConsume(const std::string &queue,
+                           const std::string &consumer_tag, bool no_local,
+                           bool no_ack, bool exclusive,
+                           boost::uint16_t message_prefetch_count,
+                           bool globalQos,
                            const Table &arguments);
 
   /**
@@ -817,6 +879,22 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
    */
   void BasicQos(const std::string &consumer_tag,
                 boost::uint16_t message_prefetch_count);
+
+  /**
+   * Modify consumer's message prefetch count
+   *
+   * Sets the number of unacknowledged messages that will be delivered
+   * by the broker to a consumer.
+   *
+   * Has no effect for consumer with `no_ack` set.
+   *
+   * @param consumer_tag The consumer tag to adjust the prefetch for.
+   * @param message_prefetch_count The number of unacknowledged message the
+   * @param globalQos Sets basic.qos.global explicitly.
+   * broker will deliver. A value of 0 means no limit.
+   */
+  void BasicQos(const std::string &consumer_tag,
+                boost::uint16_t message_prefetch_count, bool globalQos);
 
   /**
    * Cancels a previously created Consumer


### PR DESCRIPTION
There was no way to explicitly set `basic.qos.global` when using `BasicQos `or `BasicConsume`. SimpleAmqpClient library always sets this to `false `(for RabbitMq broker versions <v3.3.0 and to `true` for versions >v3.3.0. This made it impossible to set QoS with this library when used with quorum-type queues in RabbitMq >v3.3.0.

This pull request adds overrides to `BasicConsume `and `BasicQos`, where it is possible to explicitly set `basic.qos.global` setting.