### PR TITLE
Add heartbeat on OpenOpts

### DIFF
--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -54,8 +54,6 @@
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 
-#define BROKER_HEARTBEAT 0
-
 namespace AmqpClient {
 
 namespace {
@@ -122,7 +120,7 @@ Channel::ChannelImpl::~ChannelImpl() {}
 void Channel::ChannelImpl::DoLogin(const std::string &username,
                                    const std::string &password,
                                    const std::string &vhost, int frame_max,
-                                   bool sasl_external) {
+                                   int heartbeat, bool sasl_external) {
   amqp_table_entry_t capabilties[1];
   amqp_table_entry_t capability_entry;
   amqp_table_t client_properties;
@@ -142,15 +140,14 @@ void Channel::ChannelImpl::DoLogin(const std::string &username,
 
   if (sasl_external) {
     CheckRpcReply(0, amqp_login_with_properties(
-                         m_connection, vhost.c_str(), 0, frame_max,
-                         BROKER_HEARTBEAT, &client_properties,
-                         AMQP_SASL_METHOD_EXTERNAL, username.c_str()));
+                         m_connection, vhost.c_str(), 0, frame_max, heartbeat,
+                         &client_properties, AMQP_SASL_METHOD_EXTERNAL,
+                         username.c_str()));
   } else {
-    CheckRpcReply(
-        0, amqp_login_with_properties(m_connection, vhost.c_str(), 0, frame_max,
-                                      BROKER_HEARTBEAT, &client_properties,
-                                      AMQP_SASL_METHOD_PLAIN, username.c_str(),
-                                      password.c_str()));
+    CheckRpcReply(0, amqp_login_with_properties(
+                         m_connection, vhost.c_str(), 0, frame_max, heartbeat,
+                         &client_properties, AMQP_SASL_METHOD_PLAIN,
+                         username.c_str(), password.c_str()));
   }
 
   m_brokerVersion = ComputeBrokerVersion(m_connection);

--- a/src/SimpleAmqpClient/Channel.h
+++ b/src/SimpleAmqpClient/Channel.h
@@ -108,6 +108,7 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
     std::string vhost;  ///< Virtualhost on the broker. Default '/', required.
     int port;           ///< Port to connect to, default is 5672.
     int frame_max;      ///< Max frame size in bytes. Default 128KB.
+    int heartbeat;      ///< Heartbeat timer in seconds. Default 0s.
     /// One of BasicAuth or ExternalSaslAuth is required.
     boost::variant<BasicAuth, ExternalSaslAuth> auth;
     /// Connect using TLS/SSL when set, otherwise use an unencrypted channel.
@@ -128,7 +129,7 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
      */
     static OpenOpts FromUri(const std::string &uri);
 
-    OpenOpts() : vhost("/"), port(5672), frame_max(131072) {}
+    OpenOpts() : vhost("/"), port(5672), frame_max(131072), heartbeat(0) {}
     bool operator==(const OpenOpts &) const;
   };
 
@@ -924,14 +925,12 @@ class SIMPLEAMQPCLIENT_EXPORT Channel : boost::noncopyable {
                                   const std::string &username,
                                   const std::string &password,
                                   const std::string &vhost, int frame_max,
-                                  bool sasl_external);
+                                  int heartbeat, bool sasl_external);
 
-  static ChannelImpl *OpenSecureChannel(const std::string &host, int port,
-                                        const std::string &username,
-                                        const std::string &password,
-                                        const std::string &vhost, int frame_max,
-                                        const OpenOpts::TLSParams &tls_params,
-                                        bool sasl_external);
+  static ChannelImpl *OpenSecureChannel(
+      const std::string &host, int port, const std::string &username,
+      const std::string &password, const std::string &vhost, int frame_max,
+      int heartbeat, const OpenOpts::TLSParams &tls_params, bool sasl_external);
 
   /// PIMPL idiom
   boost::scoped_ptr<ChannelImpl> m_impl;

--- a/src/SimpleAmqpClient/ChannelImpl.h
+++ b/src/SimpleAmqpClient/ChannelImpl.h
@@ -60,7 +60,7 @@ class Channel::ChannelImpl : boost::noncopyable {
   typedef channel_map_t::iterator channel_map_iterator_t;
 
   void DoLogin(const std::string &username, const std::string &password,
-               const std::string &vhost, int frame_max,
+               const std::string &vhost, int frame_max, int heartbeat,
                bool sasl_external = false);
   amqp_channel_t GetChannel();
   void ReturnChannel(amqp_channel_t channel);


### PR DESCRIPTION
Add configurable heartbeat on OpenOpts.

The heartbeat default keep the value of 0 which is disabling it.