### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,10 @@ else()
 endif()
 set(Boost_USE_STATIC_RUNTIME OFF)
 
-find_package(Boost 1.47.0 COMPONENTS chrono system REQUIRED)
+find_package(Boost 1.47.0 COMPONENTS chrono REQUIRED)
+if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
+  find_package(Boost 1.47.0 COMPONENTS chrono system REQUIRED)
+endif()
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
 


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, the Boost.System stub library introduced back in 1.69[^1] has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3), which causes a CMake error.

This PR change using OPTIONAL_COMPONENTS is based on upstream comment `https://github.com/boostorg/system/issues/132#issuecomment-3146378680` given that Boost 1.47 is still supported.

EDIT: Removed OPTIONAL_COMPONENTS as it is only available from CMake 3.11

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69